### PR TITLE
Fix previewer source/preview switch

### DIFF
--- a/previewer/preview_renderer.js
+++ b/previewer/preview_renderer.js
@@ -12,6 +12,7 @@ $(document).ready(function(){
 })
 
 flipPage = function() {
+  showingSource = !showingSource;
   if (showingSource) {
     $('#preview').hide();
     $('#source_code').show();
@@ -19,7 +20,6 @@ flipPage = function() {
     $('#source_code').hide();
     $('#preview').show();
   }
-  showingSource = !showingSource;
 }
 
 setPreviewAssetID = function(ID) {


### PR DESCRIPTION
The logic for current and new source display status is inverted, thus
first click on Flip button does nothing. This is fixed by having the
showingSource variable reflect the requested state in flipPage.