### PR TITLE
Remove any 'synopsis' related code from NewsArticle class

### DIFF
--- a/examples/word_of_day.js
+++ b/examples/word_of_day.js
@@ -29,7 +29,7 @@ function ingest_article_profile(hatch, uri) {
 
         // Pluck wordOfDayDef
         const wordOfDayMixedString = $profile('td:contains("Definition:")').next().text();
-        const wordOfDayDef = wordOfDayMixedString.slice(wordOfDayMixedString.indexOf(" "));
+        const wordOfDayDef = wordOfDayMixedString.slice(wordOfDayMixedString.indexOf(" ")).trim();
         asset.set_synopsis(wordOfDayDef);
 
         // Pluck wordOfDayType

--- a/lib/index.js
+++ b/lib/index.js
@@ -147,7 +147,6 @@ class NewsArticle extends BaseAsset {
 
     set_document(value) { this._document = cheerio(value); }
     set_section(value) { this._section = value; }
-    set_synopsis(value) { this._synopsis = value; }
 
     _process() {
         return Promise.resolve().then(() => {
@@ -172,9 +171,6 @@ class NewsArticle extends BaseAsset {
     to_metadata() {
         const metadata = super.to_metadata();
         metadata['document'] = this._document.toString();
-        if (metadata['synopsis']) {
-          metadata['synopsis'] = this._synopsis.toString();
-        }
         return metadata;
     }
 


### PR DESCRIPTION
There is already a 'set_synopsis' method on NewsArticle's parent, BaseAsset. Therefore, I don't see any need to add any 'synopsis' related methods to NewsArticle, or the need to export any 'synopsis' related metadata in NewsArticle. If I'm overlooking something, please advise. My other line of thinking was to handle a !synopsis issue at the time of ingestion, but I'm going to hold on that for now.