### PR TITLE
Make bootstrap css be resolvable if we're imported as a library

### DIFF
--- a/previewer/main.html
+++ b/previewer/main.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8">
     <link href="../node_modules/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="./css/styles.css">
+    <!-- If we are running as a library, we need a different path resolution -->
+    <link href="../../bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
+
+    <link href="./css/styles.css" rel="stylesheet" >
   </head>
 
   <body>


### PR DESCRIPTION
Old code only worked properly when running from the libingester directly
but failed when run as a dependency since paths are different. We now
account for that and try to load either of the stylesheets paths so we
work on both setups.