### PR TITLE
Made libingester use timestamped directory names

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,26 @@ function new_asset_id() {
     return hash.digest('hex');
 }
 
+// Date formatting is awful in JS but using a lib was too heavy
+function getTimestamp() {
+    var date = new Date();
+
+    let year = date.getFullYear();
+    let month = date.getMonth() + 1;
+    let day = date.getDate();
+    let hour = date.getHours();
+    let minute = date.getMinutes();
+    let second = date.getSeconds();
+
+    month = (month < 10 ? "0" : "") + month;
+    day = (day < 10 ? "0" : "") + day;
+    hour = (hour < 10 ? "0" : "") + hour;
+    minute = (minute < 10 ? "0" : "") + minute;
+    second = (second < 10 ? "0" : "") + second;
+
+    return year + month + day + "_" +  hour + minute + second;
+}
+
 class ValidationError extends Error {
 }
 
@@ -216,7 +236,8 @@ class Hatch {
             name += '_';
         }
 
-        this._path = fs.mkdtempSync('hatch_' + name.toLowerCase());
+        this._path = fs.mkdirSync('hatch_' + name.toLowerCase() + getTimestamp(),
+                                  0o775);
     }
 
     _validate_asset_references() {


### PR DESCRIPTION
Without this, it's really a pain to manage the hatch folders so now wei
add a timestamp instead of a random string to it.