### PR TITLE
Bump to version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libingester",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "license": "UNLICENSED",
   "dependencies": {
     "aws-sdk": "^2.23.0",


### PR DESCRIPTION
With the article formats being merged, this is an API break. We have
already dubbed the article formats "Libingester 2" in conversations, so
it makes sense to bump to that version.

https://phabricator.endlessm.com/T17387