### PR TITLE
Add support for libingester 2.0 hatch previews

### DIFF
--- a/previewer/css/styles.css
+++ b/previewer/css/styles.css
@@ -7,6 +7,22 @@ html,body {
   display: block;
 }
 
+.preview-frame {
+  height: 100%;
+  width: 100%;
+  margin: 0px;
+  padding: 0px;
+  overflow: auto;
+  display: block;
+  margin-bottom: -2em;
+}
+
+.preview-frame-holder {
+  height: calc(100% - 3.5em);
+  padding: 0;
+  margin: 0;
+}
+
 .main-page {
   height: 100%;
   overflow: auto;

--- a/previewer/main.html
+++ b/previewer/main.html
@@ -65,7 +65,11 @@
               <code id='source_code_content'></code>
             </div>
 
-            <div class='container center-block mt-1' id='preview'></div>
+            <div class='container center-block mt-1' id='image_preview'></div>
+
+            <div class='preview-frame-holder container center-block mt-1' id='preview_frame_holder' >
+              <iframe class='preview-frame' frameborder='0' id='preview_frame'></iframe>
+            </div>
           </span>
         </div>
 

--- a/previewer/main_renderer.js
+++ b/previewer/main_renderer.js
@@ -48,12 +48,14 @@ $(document).ready(function(){
         )
       )
     } else if (asset.objectType == "ArticleObject") {
-      let thumbnail_img = '';
-      if (asset.thumbnail)
-        thumbnail_img = $('<img />', { src: hatchFolder + "/" + asset.thumbnail + ".data",
-                                       class: 'thumbnail' }).append(
-          $('<br />')
-        );
+      let thumbnail = '';
+      if (asset.thumbnail) {
+        const thumbnail_img = $('<img />', { src: hatchFolder + "/" + asset.thumbnail + ".data",
+                                           class: 'thumbnail' });
+        thumbnail = $('<div />')
+          .append(thumbnail_img)
+          .append($('<br />'));
+      }
 
       $('#documentList').append(
         $('<tr/>')
@@ -61,7 +63,7 @@ $(document).ready(function(){
           .append(
             $('<td/>')
               .attr('class', 'text-center')
-              .append(thumbnail_img)
+              .append(thumbnail)
               .append(
                 $('<a/>')
                   .attr('id', asset.assetID)

--- a/previewer/preview_renderer.js
+++ b/previewer/preview_renderer.js
@@ -9,29 +9,36 @@ showingSource = false;
 $(document).ready(function(){
   $('#flip_controls').hide();
   $('#source_code').hide();
+  $('#image_asset').hide();
 })
 
 flipPage = function() {
   showingSource = !showingSource;
   if (showingSource) {
-    $('#preview').hide();
+    $('#preview_frame').hide();
+    $('#image_preview').hide();
     $('#source_code').show();
   } else {
+    $('#preview_frame').show();
+    $('#image_preview').show();
     $('#source_code').hide();
-    $('#preview').show();
   }
 }
 
 setPreviewAssetID = function(ID) {
   if (!ID) {
-    $('#preview').html("<center><h2>No asset selected</h2></center>")
+    $('#preview_frame').html("<center><h2>No asset selected</h2></center>")
     return;
   }
 
   showingSource = false;
   $('#source_code').hide();
-  $('#preview').show();
-  $('#image_asset').remove();
+  $('#preview_frame').show();
+  $('#image_preview').show();
+
+  $('#image_preview').html('');
+  $('#preview_frame').contents().find('html').html('');
+  $('#preview_frame_holder').removeClass('preview-frame-holder');
 
   var asset = assetMap.get(ID)
 
@@ -43,9 +50,10 @@ setPreviewAssetID = function(ID) {
     $('#flip_controls').hide();
   }
 
-  $('#preview').html(asset.document || "")
   if (asset.document) {
-    $('#preview img').each(function() {
+    $('#preview_frame_holder').addClass('preview-frame-holder');
+    $('#preview_frame').contents().find('html').find('body').html(asset.document || "")
+    $('#preview_frame').contents().find('html').find('img').each(function() {
       var imgID = $(this).attr("data-soma-job-id")
       $(this).attr("src", hatchFolder + "/" + imgID + ".data")
     })
@@ -53,11 +61,11 @@ setPreviewAssetID = function(ID) {
     image_asset = $('<img />', { id: 'image_asset',
                                  src: asset.path,
                                  class: 'centered mx-auto' });
-    $('#preview').append(
+    $('#image_preview').append(
         image_asset
     )
   } else {
-    $('#preview').html("<center><h2>Unsupported asset type (" + asset.objectType + ")!</h2></center>")
+    $('#image_preview').html("<center><h2>Unsupported asset type (" + asset.objectType + ")!</h2></center>")
   }
 }
 


### PR DESCRIPTION
Since CSS can now be in the article, we needed to isolate it with an
iframe to not mess up the app styling. Fix for thumbnail on articles is
also included here.