### PR TITLE
previewer: Show article format specific metadata

### DIFF
--- a/lib/assets/blog-stylesheet.scss
+++ b/lib/assets/blog-stylesheet.scss
@@ -1,20 +1,14 @@
 $title-font: 'Fira Sans'!default;
 $body-font: 'Merriweather' !default;
-$display-font: 'Fira Sans' !default;
-$logo-font: 'Fira Sans' !default;
 $context-font: 'Fira Sans' !default;
 $support-font: 'Fira Sans' !default;
-$title-font-composite: 'Roboto' !default;
 $body-font-composite: 'Roboto' !default;
-$display-font-composite: 'Roboto' !default;
 
 $primary-light-color: #5e7790 !default;
-$primary-medium-color: #2d3e4e !default;
 $primary-dark-color: #1b242e !default;
 $accent-light-color: #ff6835 !default;
 $accent-dark-color: #cc532b !default;
 $background-light-color: #e9e9e3 !default;
-$background-dark-color: #ddddd5 !default;
 
 $black60: lighten(black, 60);
 $body-line-height: 1.5;

--- a/previewer/metadata_renderer.js
+++ b/previewer/metadata_renderer.js
@@ -17,7 +17,13 @@ const visibleProps = [ 'assetID',
                        'license',
                        'tags',
                        'lastModifiedDate',
-                       'revisionTag' ]
+                       'revisionTag',
+
+                       // Properties specific to certain asset types
+                       'author',
+                       'authors',
+                       'published',
+                       'sourceName' ]
 
 $(document).ready(function(){
 })
@@ -45,6 +51,8 @@ setMetadataAssetID = function(ID) {
     )
 
     visibleProps.forEach(function(prop) {
+      if (!asset.hasOwnProperty(prop))
+        return;
       $('#metadata_table').append(
           $('<thead/>').append(
             $('<tr/>').append(


### PR DESCRIPTION
Some metadata is only added in the case of a specific article format.
Show that in the previewer, but only if it is present.