### PR TITLE
Embedded videos are now normalized to image links

### DIFF
--- a/lib/assets/_media_link.scss
+++ b/lib/assets/_media_link.scss
@@ -1,0 +1,30 @@
+.media-link {
+  display: inline-block;
+  position: relative;
+}
+
+.media-link:after {
+  content: ' ';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  border-radius: 50%;
+  min-height: 96px;
+  min-width: 96px;
+  margin: -48px;
+  background-color: rgba(0, 0, 0, 0.6);
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.media-link.audio:after,
+.media-link.video:after {
+  // Shows a slightly transparent "play" icon
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><path style="opacity:0.6;fill:white;" d="M 30.6,14 7.6,0.4 c -1.8,-1 -3.6,-0.2 -3.6,2 v 27.2 c 0,2.2 1.8,3 3.6,2 L 30.6,18 c 1.8,-1.2 1.8,-2.8 0,-4 z" /></svg>');
+}
+
+.media-link.audio:hover:after,
+.media-link.video:hover:after {
+  // Shows an opaque "play" icon
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><path style="fill:white;" d="M 30.6,14 7.6,0.4 c -1.8,-1 -3.6,-0.2 -3.6,2 v 27.2 c 0,2.2 1.8,3 3.6,2 L 30.6,18 c 1.8,-1.2 1.8,-2.8 0,-4 z" /></svg>');
+}

--- a/lib/assets/blog-stylesheet.scss
+++ b/lib/assets/blog-stylesheet.scss
@@ -1,3 +1,5 @@
+@import '_media_link';
+
 $body-font: 'Merriweather' !default;
 $title-font: 'Fira Sans' !default;
 $context-font: 'Fira Sans' !default;

--- a/lib/assets/news-stylesheet.scss
+++ b/lib/assets/news-stylesheet.scss
@@ -1,3 +1,5 @@
+@import '_media_link';
+
 $body-font: 'Merriweather' !default;
 $title-font: 'Fira Sans' !default;
 $context-font: 'Fira Sans' !default;

--- a/lib/index.js
+++ b/lib/index.js
@@ -183,6 +183,7 @@ class BlogArticle extends BaseAsset {
         super();
         this._object_type = "ArticleObject";
         this._content_type = "text/html";
+        this._tags = [];
     }
 
     set_author(value) { this._author = value; }

--- a/lib/index.js
+++ b/lib/index.js
@@ -216,6 +216,10 @@ class BlogArticle extends BaseAsset {
         return Promise.resolve().then(() => {
             const $elem = this._document;
 
+            if (!$elem) {
+                throw new Error(`Must call asset.render() before saving BlogArticle to a hatch.`);
+            }
+
             $elem('img, video, audio').each(function() {
                 const $asset = cheerio(this);
 
@@ -388,6 +392,10 @@ class NewsArticle extends BaseAsset {
     _process() {
         return Promise.resolve().then(() => {
             const $elem = this._document;
+
+            if (!$elem) {
+                throw new Error(`Must call asset.render() before saving BlogArticle to a hatch.`);
+            }
 
             $elem('img, video, audio').each(function() {
                 const $asset = cheerio(this);

--- a/lib/util.js
+++ b/lib/util.js
@@ -58,9 +58,14 @@ function get_embedded_video_asset(video_tag, video_uri) {
     asset.set_download_uri(video_uri);
     asset.set_last_modified_date(new Date());
 
-    // all video elements should be normalized to video tags with a single
-    // source entity. db-build will populate the rest.
-    video_tag.replaceWith(`<video data-libingester-asset-id=${asset.asset_id}><source /></video>`);
+    // All video elements should be replaced with a link. An img tag with src
+    // will be populated by db-build after the thumbnail is ingested, and the
+    // link href will be filled out during the article's crosslinking process
+    // at pack time.
+    let videoAttrs = `data-soma-widget="VideoLink"`;
+    videoAttrs += ` data-libingester-asset-id="${asset.asset_id}"`;
+    videoAttrs += ` class="media-link video"`;
+    video_tag.replaceWith(`<a ${videoAttrs}></a>`);
 
     return asset;
 }

--- a/test/lib/util.test.js
+++ b/test/lib/util.test.js
@@ -183,9 +183,10 @@ describe('get_embedded_video_asset', () => {
         expect(videoAsset).to.be.instanceOf(libingester.VideoAsset);
 
         expect($('iframe').length).to.equal(0);
-        expect($('video > source').length).to.equal(2);
+        const videoLinkSelector = 'img < a[data-soma-widget="VideoLink"].media-link.video';
+        expect($(videoLinkSelector).length).to.equal(2);
 
-        const video_job_ids = $('video').map((i, v) => v.attribs['data-libingester-asset-id']).get();
+        const video_job_ids = $(videoLinkSelector).map((i, v) => v.attribs['data-libingester-asset-id']).get();
         expect(video_job_ids).to.deep.equal([iframeAsset.asset_id, videoAsset.asset_id]);
     });
 });


### PR DESCRIPTION
Instead of video tags, videos will now simply be links pointing to the
ingested video, with an image of that video's thumbnail. db-build
generates thumbnails if they're not provided, so one is not strictly
necessary.

https://phabricator.endlessm.com/T17614