### PR TITLE
Correctly left-align .article-content

### DIFF
--- a/lib/assets/gallery-image-stylesheet.scss
+++ b/lib/assets/gallery-image-stylesheet.scss
@@ -158,15 +158,13 @@ h6 {
 
 .inner-content-wrapper {
     display: flex;
-    align-items: flex-start;
-    align-content: flex-start;
-    justify-content: space-between;
+    flex-direction: row;
 }
 
 .article-support {
     font-family: $support-font;
     font-size: 0.9rem;
-    min-width: 15vw;
+    width: 15vw;
     margin-right: 50px;
 }
 


### PR DESCRIPTION
The `.article-content` div moves with window expansion, but only when there
is not enough content to horizontally expand the div. This also causes
`.article-support` to expand.

Keep .article-support static, and left-align `.article-content`.

https://phabricator.endlessm.com/T18513