### PR TITLE
gallery: Add a temoralCoverage field

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -329,6 +329,7 @@ class GalleryImageArticle extends BaseAsset {
         Object.assign(metadata, {
             'document': this._document.html(),
             'authors': [this._author],
+            'published': this._date_published.toISOString(),
             'contentDates': this._content_dates || []
         });
         return metadata;

--- a/lib/index.js
+++ b/lib/index.js
@@ -314,14 +314,19 @@ class GalleryImageArticle extends BaseAsset {
         }
     }
 
-    set_content_dates(value) {
-        this._content_dates = value.map((v) => {
+    // temporal_coverage here is an array of dates, sorted
+    // in ascending order. The consumer is responsible for
+    // translating this into something sensible in accordance
+    // with the user's localisation preferences per
+    // http://schema.org/temporalCoverage
+    set_temporal_coverage(value) {
+        this._temporal_coverage = value.map((v) => {
             if (!(v instanceof Date)) {
                 return new Date(v);
             }
 
             return v;
-        });
+        }).sort();
     }
 
     to_metadata() {
@@ -330,7 +335,7 @@ class GalleryImageArticle extends BaseAsset {
             'document': this._document.html(),
             'authors': [this._author],
             'published': this._date_published.toISOString(),
-            'contentDates': this._content_dates || []
+            'temporalCoverage': this._temporal_coverage || []
         });
         return metadata;
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -321,7 +321,8 @@ class GalleryImageArticle extends BaseAsset {
     // with the user's localisation preferences per
     // http://schema.org/temporalCoverage
     set_temporal_coverage(value) {
-        this._temporal_coverage = value.map((v) => {
+        const arrayValue = value instanceof Array ? value : [value];
+        this._temporal_coverage = arrayValue.map((v) => {
             if (!(v instanceof Date)) {
                 return new Date(v);
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -297,6 +297,7 @@ class GalleryImageArticle extends BaseAsset {
         super();
         this._object_type = "ArticleObject";
         this._content_type = "text/html";
+        this._temporal_coverage = [];
     }
 
     set_author(value) { this._author = value; }
@@ -335,7 +336,7 @@ class GalleryImageArticle extends BaseAsset {
             'document': this._document.html(),
             'authors': [this._author],
             'published': this._date_published.toISOString(),
-            'temporalCoverage': this._temporal_coverage || []
+            'temporalCoverage': this._temporal_coverage
         });
         return metadata;
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -314,12 +314,22 @@ class GalleryImageArticle extends BaseAsset {
         }
     }
 
+    set_content_dates(value) {
+        this._content_dates = value.map((v) => {
+            if (!(v instanceof Date)) {
+                return new Date(v);
+            }
+
+            return v;
+        });
+    }
+
     to_metadata() {
         const metadata = super.to_metadata();
         Object.assign(metadata, {
             'document': this._document.html(),
             'authors': [this._author],
-            'published': this._date_published.toISOString(),
+            'contentDates': this._content_dates || []
         });
         return metadata;
     }


### PR DESCRIPTION
This is used to specify the dates that the content might refer to
as opposed to the publication date of the article itself. The difference
is that the content dates should not be used for formatting, but they
might be useful for display.

https://phabricator.endlessm.com/T17886