### PR TITLE
Fix bootstrap dep issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libingester",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "license": "UNLICENSED",
   "dependencies": {
     "aws-sdk": "^2.23.0",
@@ -11,13 +11,14 @@
     "fs-extra": "^2.0.0",
     "iconv": "^2.3.0",
     "jest": "^19.0.2",
-    "jquery": "^1.7.4",
+    "jquery": "^3.2.1",
     "js-beautify": "^1.6.14",
     "moment": "^2.18.1",
     "mustache": "^2.3.0",
     "node-sass": "^4.5.3",
     "node-syntaxhighlighter": "^0.8.1",
     "parse-data-url": "^0.1.4",
+    "popper.js": "^1.11.1",
     "request": "^2.79.0",
     "request-promise": "^4.1.1",
     "tar.gz": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "aws-sdk": "^2.23.0",
-    "bootstrap": "^4.0.0-alpha.6",
+    "bootstrap": "^4.0.0-beta",
     "cheerio": "^0.22.0",
     "electron": "^1.4.1",
     "feedparser": "^2.2.0",
@@ -22,6 +22,7 @@
     "request": "^2.79.0",
     "request-promise": "^4.1.1",
     "tar.gz": "^1.0.5",
+    "tether": "^1.4.0",
     "thenify-all": "^1.6.0"
   },
   "devDependencies": {

--- a/previewer/main.html
+++ b/previewer/main.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
+
     <link href="../node_modules/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- If we are running as a library, we need a different path resolution -->
     <link href="../../bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -100,6 +101,7 @@
     try {
       global.jQuery = require('jquery');
       global.Tether = require('tether');
+      global.Popper = require('popper.js')
       require('bootstrap');
 
       require('./main_renderer.js')

--- a/previewer/package.json
+++ b/previewer/package.json
@@ -7,9 +7,11 @@
   "main": "main.js",
   "//": "XXX: Make sure to add these dependencies to libingester too - https://github.com/npm/npm/issues/13734",
   "dependencies": {
-    "bootstrap": "^4.0.0-alpha.6",
+    "bootstrap": "^4.0.0-beta",
+    "jquery": "^3.2.1",
     "js-beautify": "^1.6.14",
-    "jquery": "^1.7.4",
-    "node-syntaxhighlighter": "^0.8.1"
+    "node-syntaxhighlighter": "^0.8.1",
+    "popper.js": "^1.11.1",
+    "tether": "^1.4.0"
   }
 }


### PR DESCRIPTION
New bootstrap doesn't specify jQ as a direct dep but as a peerDependecy so this is the workaround.