### PR TITLE
Libingester: Fix wrapping problem for article-support in Gallery Articles

### DIFF
--- a/lib/assets/gallery-image-article.mst
+++ b/lib/assets/gallery-image-article.mst
@@ -52,17 +52,15 @@
 let categories = document.getElementById('article-categories');
 if (categories != null) {
     if (categories.children.length < 1) {
-        document.getElementById('article-title').className += ' no-margin-top';
+        document.getElementById('article-title').classList.add('no-margin-top');
     }
 }
 
 let article_content = document.getElementById('article-content');
-if (article_content != null) {
-    if (article_content.children.length < 1) {
-        document.getElementById('article-title').className += ' less-margin-bottom';
-        document.getElementById('article-support').className += ' width-full';
-        article_content.parentNode.removeChild(article_content);
-    }
+if (article_content && article_content.children.length < 1) {
+    document.getElementById('article-title').classList.add('less-margin-bottom');
+    document.getElementById('article-title').classList.add('width-full');
+    article_content.parentNode.removeChild(article_content);
 }
 </script>
 </body>

--- a/lib/assets/gallery-image-article.mst
+++ b/lib/assets/gallery-image-article.mst
@@ -16,7 +16,7 @@
             <div class="article-categories" id="article-categories"></div>
             <h1 class="article-title" id="article-title">{{ title }}</h1>
             <div class="inner-content-wrapper">
-                <div class="article-support">
+                <div class="article-support" id="article-support">
                     <div class="author" id="author">{{ author }}</div>
                     <div class="date-published" id="published-id"></div>
                     <div class="read-more">
@@ -60,6 +60,8 @@ let article_content = document.getElementById('article-content');
 if (article_content != null) {
     if (article_content.children.length < 1) {
         document.getElementById('article-title').className += ' less-margin-bottom';
+        document.getElementById('article-support').className += ' width-full';
+        article_content.parentNode.removeChild(article_content);
     }
 }
 </script>

--- a/lib/assets/gallery-image-stylesheet.scss
+++ b/lib/assets/gallery-image-stylesheet.scss
@@ -164,8 +164,14 @@ h6 {
 .article-support {
     font-family: $support-font;
     font-size: 0.9rem;
-    width: 15vw;
+    width: 20vw;
     margin-right: 50px;
+
+    // If there is nothing in article-content, make article-support full width
+    &.width-full {
+        width: 100%;
+        margin-right: 0;
+    }
 }
 
 .article-content {

--- a/lib/assets/gallery-video-article.mst
+++ b/lib/assets/gallery-video-article.mst
@@ -18,7 +18,7 @@
             <div class="article-categories" id="article-categories"></div>
             <h1 class="article-title" id="article-title">{{ title }}</h1>
             <div class="inner-content-wrapper">
-                <div class="article-support">
+                <div class="article-support" id="article-support">
                     <div class="author" id="author">{{ author }}</div>
                     <div class="date-published" id="published-id"></div>
                     <div class="read-more">
@@ -62,6 +62,8 @@ let article_content = document.getElementById('article-content');
 if (article_content != null) {
     if (article_content.children.length < 1) {
         document.getElementById('article-title').className += ' less-margin-bottom';
+        document.getElementById('article-support').className += ' width-full';
+        article_content.parentNode.removeChild(article_content);
     }
 }
 </script>

--- a/lib/assets/gallery-video-article.mst
+++ b/lib/assets/gallery-video-article.mst
@@ -54,17 +54,15 @@
 let categories = document.getElementById('article-categories');
 if (categories != null) {
     if (categories.children.length < 1) {
-        document.getElementById('article-title').className += ' no-margin-top';
+        document.getElementById('article-title').classList.add('no-margin-top');
     }
 }
 
 let article_content = document.getElementById('article-content');
-if (article_content != null) {
-    if (article_content.children.length < 1) {
-        document.getElementById('article-title').className += ' less-margin-bottom';
-        document.getElementById('article-support').className += ' width-full';
-        article_content.parentNode.removeChild(article_content);
-    }
+if (article_content && article_content.children.length < 1) {
+    document.getElementById('article-title').classList.add('less-margin-bottom');
+    document.getElementById('article-title').classList.add('width-full');
+    article_content.parentNode.removeChild(article_content);
 }
 </script>
 </body>

--- a/lib/assets/gallery-video-stylesheet.scss
+++ b/lib/assets/gallery-video-stylesheet.scss
@@ -169,8 +169,14 @@ h6 {
 .article-support {
     font-family: $support-font;
     font-size: 0.9rem;
-    width: 15vw;
+    width: 20vw;
     margin-right: 50px;
+
+    // If there is nothing in article-content, make article-support full width
+    &.width-full {
+        width: 100%;
+        margin-right: 0;
+    }
 }
 
 .article-content {


### PR DESCRIPTION
The `.article-support` div that holds the original URI is too narrow.
- I gave it a little more width: 15vw to 20vw
- when there's nothing in the body of the content, the width of `.article-support` should be 100%, and the `.article-content` div is removed.

https://phabricator.endlessm.com/T18790