### PR TITLE
Don't warn when output dir exists

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -705,8 +705,6 @@ class Hatch {
 
         if (!fs.existsSync(this._path)) {
             fs.mkdirSync(this._path, 0o775);
-        } else {
-            console.warn("WARNING! Path already exists!");
         }
     }
 


### PR DESCRIPTION
The vast majority of the time libingester is invoked (i.e. on SOMA by
libingester-worker) the dir is created, giving spurious warnings on each
run