### PR TITLE
Article pages: fix scope in inline Javascript

### DIFF
--- a/lib/assets/blog-article.mst
+++ b/lib/assets/blog-article.mst
@@ -46,7 +46,7 @@
         let metadata = window.contentMetadata;
         function links_helper(links_id, featured, separator) {
             let links = document.getElementById(links_id);
-            links.innerHTML = metadata.sets
+            links.innerHTML = window.contentMetadata.sets
                 .filter(set => set.featured === featured)
                 .map(set => '<a class="eos-show-link" href="' + set.id + '">' + set.title + '</a>')
                 .join(separator);


### PR DESCRIPTION
The variable metadata gives ReferenceError inside the function
links_helper().

https://phabricator.endlessm.com/T19904
https://phabricator.endlessm.com/T19502
https://phabricator.endlessm.com/T19792
https://phabricator.endlessm.com/T19356
https://phabricator.endlessm.com/T19904
https://phabricator.endlessm.com/T19457