### PR TITLE
Allow RSS enty values to be overridden

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -227,6 +227,18 @@ function encode_uri(uri) {
 exports.encode_uri = encode_uri;
 
 function fetch_rss_entries (feed, max_items=Infinity, max_days_old=1) {
+    // Allow environment variables to override this
+    try {
+        if (process.env.LIBINGESTER_MAX_ITEMS) {
+            max_items = parseInt(process.env.LIBINGESTER_MAX_ITEMS);
+        }
+        if (process.env.LIBINGESTER_MAX_DAYS_OLD) {
+            max_days_old = parseInt(process.env.LIBINGESTER_MAX_DAYS_OLD);
+        }
+    } catch (err) {
+        throw new Error(`Couldn't parse RSS entry overrides: ${err}`);
+    }
+
     const oldest_date = moment().subtract(max_days_old, 'days');
 
     return _fetch_rss_page(feed, 1, [], max_items, oldest_date);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libingester",
-  "version": "2.2.30",
+  "version": "2.2.31",
   "license": "UNLICENSED",
   "dependencies": {
     "aws-sdk": "^2.23.0",


### PR DESCRIPTION
Since parameterizing these over the command line would necessitate
manual changes to every single ingester script, let's just use the
environment.

https://phabricator.endlessm.com/T19959