### PR TITLE
Fix GalleryVideo header image size restriction

### DIFF
--- a/lib/assets/gallery-video-stylesheet.scss
+++ b/lib/assets/gallery-video-stylesheet.scss
@@ -59,10 +59,15 @@ h1 {
     img {
         display: block;
         margin: auto;
-        width: 100%;
+        width: auto;
+        min-height: inherit;
+        max-height: inherit;
+        max-width: inherit;
     }
     .main-image-link {
-        width: 100%;
+        display: block;
+        max-height: 432px;
+        max-width: 100%;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libingester",
-  "version": "2.2.31",
+  "version": "2.2.32",
   "license": "UNLICENSED",
   "dependencies": {
     "aws-sdk": "^2.23.0",


### PR DESCRIPTION
Restricts the header image in the gallery video article page from becoming too tall (particularly if the preview image is too tall). Design QA done by me.

Missed this in my last PR done on the header image CSS.

https://phabricator.endlessm.com/T20039