### PR TITLE
Article CSS: Changing title color base to $primary-medium-color

### DIFF
--- a/lib/assets/_base.scss
+++ b/lib/assets/_base.scss
@@ -39,7 +39,7 @@ p, ul {
 }
 
 h1, h2, h3, h4, h5, h6 {
-    color: $primary-dark-color;
+    color: $primary-medium-color;
     font-family: $title-font;
     font-weight: bold;
     line-height: 1.25;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libingester",
-  "version": "2.2.33",
+  "version": "2.2.34",
   "license": "UNLICENSED",
   "dependencies": {
     "aws-sdk": "^2.23.0",


### PR DESCRIPTION
The CSS for the article title was incorrectly styled as $primary-dark-color. (I think this was actually in an earlier design spec, which was a mistake.) It should be $primary-medium-color. Caught this while QA-ing various apps that had the incorrect title colors.