### PR TITLE
gallery: Make img selector more specific

### DIFF
--- a/lib/assets/gallery-image-stylesheet.scss
+++ b/lib/assets/gallery-image-stylesheet.scss
@@ -16,7 +16,7 @@ body {
 
 // Semantic elements
 
-img {
+figure img {
     width: 100%;
     height: auto;
 }

--- a/lib/assets/gallery-video-stylesheet.scss
+++ b/lib/assets/gallery-video-stylesheet.scss
@@ -17,7 +17,7 @@ body {
 
 // Semantic elements
 
-img {
+figure img {
     width: 100%;
     height: auto;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libingester",
-  "version": "2.2.34",
+  "version": "2.2.35",
   "license": "UNLICENSED",
   "dependencies": {
     "aws-sdk": "^2.23.0",


### PR DESCRIPTION
The previous selector would apply the rule to the social sharing icons,
which would mess up their padding because they were given a width of 100%.

https://phabricator.endlessm.com/T20019