### PR TITLE
Add $primary-medium-color to _colors.scss & Bump libingester version

### DIFF
--- a/lib/assets/_colors.scss
+++ b/lib/assets/_colors.scss
@@ -1,4 +1,5 @@
 $primary-light-color: #5e7790 !default;
+$primary-medium-color: #2d3e4e !default;
 $primary-dark-color: #1b242e !default;
 
 $accent-light-color: #ff6835 !default;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libingester",
-  "version": "2.2.35",
+  "version": "2.2.36",
   "license": "UNLICENSED",
   "dependencies": {
     "aws-sdk": "^2.23.0",


### PR DESCRIPTION
This $primary-medium-color is the same color definition as the colors in the Endless SDK.