### PR TITLE
Allow to set tags to any asset

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,6 +83,7 @@ class BaseAsset {
     constructor() {
         this._asset_id = new_asset_id();
         this._ekn_tags = [];
+        this._tags = [];
     }
 
     get asset_id() { return this._asset_id; }
@@ -94,6 +95,7 @@ class BaseAsset {
     set_last_modified_date(value) { this._last_modified_date = _ensure_date(value); }
     set_date_published(value) { this._date_published = _ensure_date(value); }
     set_license(value) { this._license = value; }
+    set_tags (value) { this._tags = value; }
 
     _normalize_tags() {
         return this._make_tags().concat(this._ekn_tags)
@@ -137,7 +139,7 @@ class BaseAsset {
 
     _process() { return Promise.resolve(); }
 
-    _make_tags() { return []; }
+    _make_tags() { return this._tags; }
 
     _save_to_hatch(hatch) {
         const hatch_path = hatch._path;
@@ -304,8 +306,6 @@ class DictionaryAsset extends BaseAsset {
         });
         this._document = cheerio.load(body);
     }
-
-    _make_tags() { return this._tags; }
 }
 
 exports.DictionaryAsset = DictionaryAsset;
@@ -405,8 +405,6 @@ class BlogArticle extends BaseAsset {
 
         this._document = cheerio.load(document);
     }
-
-    _make_tags() { return this._tags; }
 
     _get_dependent_asset_ids() {
         return this._document('[data-soma-job-id]').map(function() {
@@ -523,8 +521,6 @@ class GalleryImageArticle extends BaseAsset {
         this._document = cheerio.load(document);
     }
 
-    _make_tags() { return this._tags; }
-
     _get_dependent_asset_ids() {
         return this._document('[data-soma-job-id]').map(function() {
             return cheerio(this).attr('data-soma-job-id');
@@ -628,8 +624,6 @@ class GalleryVideoArticle extends BaseAsset {
         this._document = cheerio.load(document);
     }
 
-    _make_tags() { return this._tags; }
-
     _get_dependent_asset_ids() {
         return this._document('[data-soma-job-id]').map(function() {
             return cheerio(this).attr('data-soma-job-id');
@@ -659,7 +653,8 @@ class NewsArticle extends BaseAsset {
         this._main_image_caption = _ensure_cheerio(caption);
     }
 
-    set_section(value) { this._section = value; }
+    set_tags(value) { throw new Error(`Use set_section() for NewsArticle`); }
+    set_section(value) { super.set_tags([value]); }
     set_as_static_page() { this._ekn_tags.push(EKN_STATIC_TAG); }
     set_source(value) { this._source = value; }
     set_lede(value) { this._lede = _fix_links(_ensure_cheerio(value)); }
@@ -763,8 +758,6 @@ class NewsArticle extends BaseAsset {
         });
         return metadata;
     }
-
-    _make_tags() { return [ this._section ]; }
 
     _get_dependent_asset_ids() {
         return this._document('[data-soma-job-id]').map(function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libingester",
-  "version": "2.2.37",
+  "version": "2.2.38",
   "license": "UNLICENSED",
   "dependencies": {
     "aws-sdk": "^2.23.0",

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -297,6 +297,15 @@ function expectPromiseRejects (p) {
     }, () => {});
 }
 
+describe('MockAsset', function() {
+    it('can set tags', function() {
+        const asset = new MockAsset();
+        asset.set_tags(['some', 'tags']);
+        const metadata = asset.to_metadata();
+        expect(metadata['tags']).to.deep.equal(['some', 'tags']);
+    });
+});
+
 describe('ImageAsset', function() {
     it('can serialize out correctly', function() {
         const asset = new libingester.ImageAsset();
@@ -469,4 +478,9 @@ describe('NewsAsset', function() {
         // Regex handles how libsass might minify the rendered CSS
         expect(metadata['document']).to.match(/\*\s*{\s*color:\s*red;?\s*}/);
     });
+
+    it('cannot use set_tags', function() {
+        expect(asset.set_tags).to.throw();
+    });
+
 });


### PR DESCRIPTION
Unify the API across all different asset types. The exception is
NewsArticle, for which we only allow one tag as the section.

https://phabricator.endlessm.com/T20295