### PR TITLE
download_image: fix case-sensitive matching

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -133,7 +133,7 @@ function download_image(uri) {
         }
 
         const content_type = response.headers['content-type'];
-        if (!content_type.startsWith('image/')) {
+        if (content_type.match(/^image/i) === null) {
             throw new Error(`Request for image ${uri} resulted in a non-image: ${content_type}`);
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libingester",
-  "version": "2.2.38",
+  "version": "2.2.39",
   "license": "UNLICENSED",
   "dependencies": {
     "aws-sdk": "^2.23.0",


### PR DESCRIPTION
Apparently mimetypes, while traditionally written as lower-case, are
actually case-insensitive.