### PR TITLE
Fix issues with trying to set empty synopsis

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,12 @@ function _ensure_date (value) {
     }
 }
 
-function _ensure_newline (value) {
+function _ensure_synopsis (value) {
+     if (value === undefined) {
+         console.error(`WARNING: Trying to set an empty synopsis! This is most likely an error in the ingester!`);
+         return null;
+     }
+
     return value.trim().replace(/[\s]{1,}/g," ");
 }
 
@@ -93,7 +98,7 @@ class BaseAsset {
     get asset_id() { return this._asset_id; }
 
     set_title(value) { this._title = value.trim(); }
-    set_synopsis(value) { this._synopsis = _ensure_newline(value); }
+    set_synopsis(value) { this._synopsis = _ensure_synopsis(value); }
     set_thumbnail(value) { this._thumbnail_asset_id = value.asset_id; }
     set_canonical_uri(value) { this._canonical_uri = value; }
     set_last_modified_date(value) { this._last_modified_date = _ensure_date(value); }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libingester",
-  "version": "2.2.41",
+  "version": "2.2.42",
   "license": "UNLICENSED",
   "dependencies": {
     "aws-sdk": "^2.23.0",

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -304,6 +304,11 @@ describe('MockAsset', function() {
         const metadata = asset.to_metadata();
         expect(metadata['tags']).to.deep.equal(['some', 'tags']);
     });
+
+    it('can set null synopsis', function() {
+        const asset = new MockAsset();
+        expect(() => { asset.set_synopsis(undefined) }).to.not.throw();
+    });
 });
 
 describe('ImageAsset', function() {


### PR DESCRIPTION
Old code would break on trying to set empty synopsis. This change now
makes sure that we don't do that since the synopsis is optional anyways.