### PR TITLE
index: add setter for sequenceNumber metadata

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -103,6 +103,7 @@ class BaseAsset {
     set_canonical_uri(value) { this._canonical_uri = value; }
     set_last_modified_date(value) { this._last_modified_date = _ensure_date(value); }
     set_date_published(value) { this._date_published = _ensure_date(value); }
+    set_sequence_number(value) { this._sequence_number = value; }
     set_license(value) { this._license = value; }
     set_tags (value) { this._tags = value; }
 
@@ -136,6 +137,8 @@ class BaseAsset {
             metadata.lastModifiedDate = this._last_modified_date.toISOString();
             metadata.revisionTag = this._last_modified_date.toISOString();
         }
+        if (this._sequence_number)
+            metadata.sequenceNumber = this._sequence_number;
         if (this._license)
             metadata.license = this._license;
         if (this._synopsis)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libingester",
-  "version": "2.2.44",
+  "version": "2.2.45",
   "license": "UNLICENSED",
   "dependencies": {
     "aws-sdk": "^2.23.0",


### PR DESCRIPTION
There are now EKN templates able to sort sets and articles using the
sequenceNumber metadata.  This is useful for static ingesters.  For
example, to create videos lesson apps.

Example app already using this metadata:
https://github.com/endlessm/eos-subscriptions-apps/blob/master/com.endlessm.math.vi/content/db.json