### PR TITLE
util: Use iconv-lite instead of node-iconv

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -9,7 +9,7 @@ const parseDataUrl = require('parse-data-url');
 const request = require('request');
 const somaDOM = require('./soma_dom');
 const url = require('url');
-const iconv = require('iconv');
+const iconv = require('iconv-lite');
 
 const USER_AGENT = 'libingester';
 
@@ -86,12 +86,11 @@ function fetch_html(uri, encoding) {
     return fetchWithRetry(options).then(res => {
         let body = res.body;
 
-        // Note that we only support the encoding types provided by node-iconv:
-        // https://github.com/bnoordhuis/node-iconv#supported-encodings
-        if (encoding) {
-            const converter = new iconv.Iconv(encoding, 'UTF-8');
-            body = converter.convert(body);
-        }
+        // Note that we only support the encoding types provided by iconv-lite:
+        // https://github.com/ashtuchkin/iconv-lite/wiki/Supported-Encodings
+        if (encoding)
+            body = iconv.encode(iconv.decode(body, encoding), 'UTF-8');
+
         return cheerio.load(body);
     });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libingester",
-  "version": "2.2.49",
+  "version": "2.3.0",
   "license": "UNLICENSED",
   "dependencies": {
     "aws-sdk": "^2.23.0",
@@ -10,7 +10,7 @@
     "feedparser": "^2.2.0",
     "file-type": "^6.1.0",
     "fs-extra": "^2.0.0",
-    "iconv": "^2.3.0",
+    "iconv-lite": "^0.4.19",
     "jest": "^19.0.2",
     "jquery": "^3.2.1",
     "js-beautify": "^1.6.14",

--- a/test/lib/util.test.js
+++ b/test/lib/util.test.js
@@ -158,14 +158,15 @@ describe('download_img', function() {
 // FIXME this text intermittently fails because it reaches out to an external
 // server. We should replace it with gzipped content served locally
 describe('fetch_html', () => {
-    it('can handle gzipped responses', () => {
+    it('can handle gzipped responses', done => {
         const test_url = 'https://www.kapanlagi.com/' +
                         'intermezzone/' +
                         'bule-amerika-ini-nyoba-makan-buah-duku-ekspresinya-nggak-nahan-aee243.html';
         const doctype = '<!DOCTYPE html>';
         return util.fetch_html(test_url).then((result) => {
             expect(result.html().substring(0, doctype.length)).to.equal(doctype);
-        });
+        })
+        .finally(done);
     });
 });
 

--- a/test/lib/util.test.js
+++ b/test/lib/util.test.js
@@ -155,14 +155,23 @@ describe('download_img', function() {
     });
 });
 
-// FIXME this text intermittently fails because it reaches out to an external
-// server. We should replace it with gzipped content served locally
+// FIXME these tests intermittently fail because they reach out to external
+// servers. We should replace them with content served locally
 describe('fetch_html', () => {
+    const doctype = '<!DOCTYPE html>';
+
+    it('works', done => {
+        const test_url = 'https://creativecommons.org/blog';
+        return util.fetch_html(test_url).then(result => {
+            expect(result.html().substring(0, doctype.length)).to.equal(doctype);
+        })
+        .finally(done);
+    });
+
     it('can handle gzipped responses', done => {
         const test_url = 'https://www.kapanlagi.com/' +
                         'intermezzone/' +
                         'bule-amerika-ini-nyoba-makan-buah-duku-ekspresinya-nggak-nahan-aee243.html';
-        const doctype = '<!DOCTYPE html>';
         return util.fetch_html(test_url).then((result) => {
             expect(result.html().substring(0, doctype.length)).to.equal(doctype);
         })


### PR DESCRIPTION
iconv-lite is possible to install without having to build native code.

Minor version bump instead of micro, because it's possible that an
ingester might be using an esoteric encoding that isn't supported by
iconv-lite.

https://phabricator.endlessm.com/T20985