### PR TITLE
T20761: Add 'wrapper' and 'wraps' properties to video objects and articles

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -569,6 +569,7 @@ class GalleryVideoArticle extends BaseAsset {
         Object.assign(metadata, {
             'document': this._document.html(),
             'authors': [this._author],
+            'wraps': [this._main_video],
         });
         return metadata;
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -252,6 +252,24 @@ class VideoAsset extends BaseAsset {
 
     set_download_uri(value) { this._download_uri = value; }
 
+    // Set a wrapper article asset ID on this video. This way,
+    // consumers can know if this article is merely just wrapping
+    // another video asset and can go directly to the video if
+    // appropriate
+    set_wrapper(article) {
+        // We can't really do validation here, any article could wrap
+        // a video asset and all article types derive from BaseAsset.
+        this._wrapper = article.asset_id;
+    }
+
+    to_metadata() {
+        const metadata = super.to_metadata();
+        Object.assign(metadata, {
+            'wrapper': this._wrapper,
+        });
+        return metadata;
+    }
+
     _save_to_hatch(hatch) {
         hatch._videos.push({
             asset_id: this.asset_id,


### PR DESCRIPTION
This PR adds a 'wrapper' and 'wraps' property to video objects and articles respectively to indicate a "thinly-wraps" relationship. This kind of relationship is currently seen with the video apps that make use of `GalleryVideoArticle` - a piece of HTML that just has a title and embedded video to play in the respective application.

Some consumers of content aren't particularly interested in these wrapper articles and want to just show the underlying content directly. They need some way of excluding the wrapper articles from the search results and including the wrapped content instead. These two properties are indicative of the fact that such a relationship exists between an article and a media object and the shard packers and tag objects accordingly.

https://phabricator.endlessm.com/T20761