### PR TITLE
previewer: Improve sidebar usability

### DIFF
--- a/previewer/css/styles.css
+++ b/previewer/css/styles.css
@@ -97,11 +97,6 @@ div.syntaxhighlighter > table {
   background-color: #f5f5f5;
 }
 
-.current {
-  font-weight: bold;
-  text-decoration: underline;
-}
-
 .tagList {
   padding: 0.3em;
 }

--- a/previewer/main.html
+++ b/previewer/main.html
@@ -31,7 +31,7 @@
 
               <div id="collapse_documents" class="collapse show" role="tabpanel" aria-labelledby="heading_documents">
                 <div class="card-block m-0 p-0 asset-list">
-                  <table class='table table-striped table-hover table-sm mb-0'>
+                  <table class='table table-hover table-sm mb-0'>
                     <tbody id="documentList"></tbody>
                   </table>
                 </div>
@@ -48,7 +48,7 @@
               </div>
               <div id="collapse_images" class="collapse" role="tabpanel" aria-labelledby="heading_images">
                 <div class="card-block m-0 p-0 asset-list">
-                  <table class='table table-striped table-hover table-sm'>
+                  <table class='table table-hover table-sm'>
                     <tbody id="imageList"></tbody>
                   </table>
                 </div>

--- a/previewer/main_renderer.js
+++ b/previewer/main_renderer.js
@@ -73,10 +73,10 @@ $(document).ready(function(){
         )
       )
 
-      // give a 'curent' class to clicked items in the documentList
+      // give an 'active' class to clicked items in the documentList
       $('tr').on('click', function(){
-        $(this).addClass('current');
-        $(this).siblings('.current').toggleClass('current');
+        $(this).addClass('table-active');
+        $(this).siblings('.table-active').toggleClass('table-active');
       })
 
     } else {


### PR DESCRIPTION
As a regular user of libingester-previewer, I find a bit confusing to
see the selected row in the sidebar, because of the striped rows.  It
also makes the text bold in the selected row, resizing the text and
flickering because often the line number changes.

This commit removes striped rows, and uses the bootstrap class to make
rows active.