### PR TITLE
tests: make tests pass more often

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "chai": "^3.5.0",
     "documentation": "^5.3.5",
     "jshint": "^2.9.5",
-    "mocha": "^3.2.0",
+    "mocha": "^4.1.0",
     "mocha-jenkins-reporter": "^0.3.7",
     "proxyquire": "^1.8.0"
   },

--- a/test/lib/util.test.js
+++ b/test/lib/util.test.js
@@ -157,8 +157,9 @@ describe('download_img', function() {
 
 // FIXME these tests intermittently fail because they reach out to external
 // servers. We should replace them with content served locally
-describe('fetch_html', () => {
+describe('fetch_html', function () {
     const doctype = '<!DOCTYPE html>';
+    this.timeout(5000);
 
     it('works', () => {
         const test_url = 'https://creativecommons.org/blog';


### PR DESCRIPTION
By bumping Mocha dependency to v4 and increasing the timeout of the
'fetch_html' tests from 2 seconds (default) to 5 seconds.

The function in 'fetch_html' is changed because arrow functions are
discouraged in Mocha: https://mochajs.org/#arrow-functions