### PR TITLE
lib: Add set_parent_asset_id to BaseAsset

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -98,6 +98,12 @@
                       </a></li>
                       
                       <li><a
+                        href='#baseassetset_parent'
+                        class='regular pre-open'>
+                        #set_parent
+                      </a></li>
+                      
+                      <li><a
                         href='#baseassetto_data'
                         class='regular pre-open'>
                         #to_data
@@ -1060,6 +1066,67 @@ in your app using other tools.</p>
           <div>
             <span class='code bold'>value</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>)</code>
 	    List of ID strings
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='baseassetset_parent'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>set_parent(parent_asset_id)</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>Set the parent asset ID, being the asset ID that embeds
+this asset.</p>
+
+
+  <div class='pre p1 fill-light mt0'>set_parent(parent_asset_id: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>parent_asset_id</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    The asset ID of this asset's parent.
 
           </div>
           

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,6 +94,7 @@ class BaseAsset {
         this._asset_id = new_asset_id();
         this._ekn_tags = [];
         this._tags = [];
+        this._parent_asset_id = null;
     }
 
     /**
@@ -156,6 +157,14 @@ class BaseAsset {
      */
     set_tags (value) { this._tags = value; }
 
+    /**
+     * Set the parent asset ID, being the asset ID that embeds
+     * this asset.
+     *
+     * @param {string} parent_asset_id - The asset ID of this asset's parent.
+     */
+    set_parent(parent_asset_id) { this._parent_asset_id = parent_asset_id; }
+
     _normalize_tags() {
         return this._make_tags().concat(this._ekn_tags)
             .filter(tag => typeof tag === 'string')
@@ -200,6 +209,8 @@ class BaseAsset {
             metadata.synopsis = this._synopsis;
         if (this._thumbnail_asset_id)
             metadata.thumbnail = this._thumbnail_asset_id;
+        if (this._parent_asset_id)
+            metadata.parent = this._parent_asset_id;
 
         return metadata;
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libingester",
   "description": "Library for creation of packaged website data ('hatches').",
-  "version": "2.4.3",
+  "version": "2.4.6",
   "license": "LGPL 2.1",
   "homepage": "https://github.com/endlessm/libingester",
   "author": "Endless Mobile Inc",


### PR DESCRIPTION
This can be used to explicitly indicate which asset ID is the
"parent" to this one, for instance, the asset which embeds a video
or an image.

It needs to be set explicitly, since we don't have a guarantee that
toplevel assets will be processed and saved before child assets, so
there's no way to look up an asset's parents at processing time.

https://phabricator.endlessm.com/T21114