### PR TITLE
index: Undeprecate GalleryVideoArticle

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -695,8 +695,6 @@ class GalleryVideoArticle extends BaseAsset {
         super();
         this._object_type = "ArticleObject";
         this._content_type = "text/html";
-
-        console.warn('GalleryVideoArticle is deprecated. Use VideoArticle instead.');
     }
 
     set_author(value) { this._author = value; }


### PR DESCRIPTION
Turns out that there is actually a use for this, in particular, for
videos that need some sort of surrounding context.

https://phabricator.endlessm.com/T20761