### PR TITLE
Save video metadata to the hatch as well

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -341,6 +341,17 @@ class VideoAsset extends BaseAsset {
             uri: this._download_uri,
             title: this._title,
         });
+
+        const metadata = this.to_metadata();
+        verify.verify_metadata(metadata);
+        let metadata_text = JSON.stringify(metadata, null, 2);
+        hatch._promises.push(
+            fs.writeFile(path.join(hatch._path, `${this._asset_id}.metadata`),
+                metadata_text)
+            .catch(err => {
+                console.log(err);
+                hatch._failed_assets.push(this);
+            }));
     }
 }
 

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -18,7 +18,6 @@ function verify_metadata(metadata) {
 
     assert((metadata['assetID'].length === 40), "Asset has invalid assetID");
     assert(typeof metadata['canonicalURI'] === "string", "Asset has invalid canonicalURI");
-    assert(typeof metadata['contentType'] === "string", "Asset has invalid contentType");
 
     assert(!!metadata['matchingLinks'], "Asset missing matchingLinks");
     assert(metadata['matchingLinks'].every((s) => (typeof s === "string")), "Some asset matching URIs are not strings");
@@ -27,6 +26,9 @@ function verify_metadata(metadata) {
     assert(metadata['tags'].every((s) => (typeof s === "string")), "Some asset tags are not strings");
 
     assert(!!metadata['revisionTag'], "Asset missing revisionTag");
+
+    if (object_type !== 'VideoObject')
+        assert(typeof metadata['contentType'] === "string", "Asset has invalid contentType");
 
     if (object_type === 'ArticleObject') {
         // XXX: This should be really attached to stuff that can show up in sets / search
@@ -41,6 +43,8 @@ function verify_metadata(metadata) {
     } else if (object_type === "DictionaryWordObject") {
         assert(!!metadata['word'], "metadata missing word");
         assert(!!metadata['definition'], "metadata missing definition");
+    } else if (object_type === 'VideoObject') {
+        assert(!metadata['contentType'], "Video object should have its contentType set later");
     } else {
         throw new VerificationError("metadata has wrong objectType");
     }


### PR DESCRIPTION
Previously, any metadata set on a VideoAsset was discarded.

https://phabricator.endlessm.com/T21578