### PR TITLE
Video metadata: fallbacks for canonical URI and matching links

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -361,6 +361,15 @@ class VideoAsset extends BaseAsset {
             hatch._failed_assets.push(this);
         }));
     }
+
+    to_metadata() {
+        const metadata = super.to_metadata();
+        metadata.canonicalURI = metadata.canonicalURI || this._download_uri;
+        if (!metadata.matchingLinks.length || !metadata.matchingLinks[0]) {
+            metadata.matchingLinks = [this._download_uri];
+        }
+        return metadata;
+    }
 }
 
 exports.VideoAsset = VideoAsset;


### PR DESCRIPTION
When metadata was added for videos in a1d42969, the canonical URI and
matching links became mandatory.  This fallbacks both to the download
URI.

https://phabricator.endlessm.com/T21734