### PR TITLE
util: RSS fetch: Add retry with exponential backoff

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -398,6 +398,27 @@ function _fetch_rss_json (feed_url) {
     });
 }
 
+function _fetch_rss_json_retrying(feed_url, attempt=1) {
+    return _fetch_rss_json(feed_url).catch(err => {
+        if (attempt > MAX_RETRIES) {
+            logger.warn(`Max retries (${MAX_RETRIES}) exceeded!`);
+            throw err;
+        }
+
+        if (['Not a feed', 'Unexpected end'].includes(err.message)) {
+            const timeout = Math.pow(2, attempt) * RETRY_BACKOFF_DELAY;
+            logger.debug(`Delaying execution of ${feed_url} by ${timeout}`);
+            return delayExecution(timeout).then(() => {
+                return _fetch_rss_json_retrying(feed_url, attempt + 1);
+            });
+        }
+
+        // We reach here if unexpected error
+        throw err;
+    });
+}
+
+
 function _fetch_rss_page (feed, page, items, all_items, max_items, oldest_date) {
     let feed_obj, is_paginated;
     if (typeof feed === 'function') {
@@ -415,7 +436,7 @@ function _fetch_rss_page (feed, page, items, all_items, max_items, oldest_date) 
     }
 
     logger.debug(`fetching RSS ${feed_url}`);
-    return _fetch_rss_json(feed_url).then(feed_json => {
+    return _fetch_rss_json_retrying(feed_url).then(feed_json => {
         const recent_enough_items = feed_json.items.filter(item => item.pubdate >= oldest_date && !all_items.has(item.link));
         const limited_items = recent_enough_items.slice(0, max_items - items.length);
         const new_items = items.concat(limited_items);


### PR DESCRIPTION
For errors 'Unexpected end' and 'Not a feed' thrown by the FeedParser
library.

https://phabricator.endlessm.com/T21793