### PR TITLE
util: Atomatically paginate Wordpress feeds

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -398,6 +398,16 @@ function _fetch_rss_json (feed_url) {
     });
 }
 
+function _is_wordpress_feed(feed_json) {
+    const has_generator = feed_json.meta.generator &&
+          feed_json.meta.generator.startsWith('https://wordpress.org/');
+    const has_xmlns = feed_json.meta['rss:site'] &&
+          feed_json.meta['rss:site']['@'] &&
+          feed_json.meta['rss:site']['@']['xmlns'] &&
+          feed_json.meta['rss:site']['@']['xmlns'].startsWith('com-wordpress');
+    return has_generator || has_xmlns;
+}
+
 function _fetch_rss_json_retrying(feed_url, attempt=1) {
     return _fetch_rss_json(feed_url).catch(err => {
         if (attempt > MAX_RETRIES) {
@@ -418,21 +428,24 @@ function _fetch_rss_json_retrying(feed_url, attempt=1) {
     });
 }
 
-
 function _fetch_rss_page (feed, page, items, all_items, max_items, oldest_date) {
-    let feed_obj, is_paginated;
-    if (typeof feed === 'function') {
-        is_paginated = true;
-        feed_obj = feed(page);
-    } else {
-        is_paginated = false;
-        feed_obj = feed;
+    let is_paginated = false;
+    let feed_url;
+
+    let feed_obj = feed;
+    if (Array.isArray(feed)) {
+        feed_obj = feed[0];
     }
 
-    let feed_url = feed_obj, is_array = false;
-    if (Array.isArray(feed_obj)) {
-        is_array = true;
-        feed_url = feed_obj.shift();
+    if (typeof feed_obj === 'function') {
+        is_paginated = true;
+        feed_url = feed_obj(page);
+    } else {
+        feed_url = feed_obj;
+    }
+
+    if (!feed_url) {
+        return Array.from(all_items);
     }
 
     logger.debug(`fetching RSS ${feed_url}`);
@@ -443,22 +456,53 @@ function _fetch_rss_page (feed, page, items, all_items, max_items, oldest_date) 
 
         // If we've run into articles which are too old, or we've hit the max
         // number of items, cease crawling
-        const done_crawling = (limited_items.length < feed_json.items.length);
+        const done_crawling = (feed_json.items.length === 0 ||
+                               limited_items.length < feed_json.items.length);
 
-        if ((is_paginated || is_array) && !done_crawling) {
-            const new_all_items = new Set(function* () { yield* all_items; yield* new_items.map(item => item.link); }());
+        const new_all_items = new Set(function* () { yield* all_items; yield* new_items.map(item => item.link); }());
 
-            if (is_paginated)
-                return _fetch_rss_page(feed, page + 1, new_items, new_all_items, max_items, oldest_date);
-            else
-                return _fetch_rss_page(feed, page, new_items, new_all_items, max_items, oldest_date);
-        } else {
-            return new_items;
+        if ((typeof feed_obj !== 'function') && _is_wordpress_feed(feed_json)) {
+            logger.debug('Wordpress feed found, adding pagination');
+            is_paginated = true;
+            const new_feed = _do_create_wordpress(feed_obj);
+            if (Array.isArray(feed)) {
+                feed.shift();
+                feed = [new_feed].concat(feed);
+            } else {
+                feed = new_feed;
+            }
         }
+
+        const _continue = Array.isArray(feed) ||
+              (!done_crawling && is_paginated);
+
+        if (!_continue) {
+            return Array.from(new_all_items);
+        }
+
+        let new_page;
+        if (done_crawling && is_paginated && Array.isArray(feed)) {
+            feed.shift();
+            new_page = 1;
+        } else {
+            if (is_paginated) {
+                new_page = page + 1;
+            } else if (Array.isArray(feed)) {
+                feed.shift();
+                new_page = 1;
+            }
+        }
+        return _fetch_rss_page(feed, new_page, new_items, new_all_items, max_items, oldest_date);
     });
 }
 
 exports.fetch_rss_entries = fetch_rss_entries;
+
+function _do_create_wordpress (feed) {
+    return function (page_num) {
+        return `${feed}?paged=${page_num}`;
+    };
+}
 
 /**
  * A utility to create a pagination function for Wordpress-generated feeds,
@@ -471,13 +515,10 @@ exports.fetch_rss_entries = fetch_rss_entries;
  * @memberof util
  */
 function create_wordpress_paginator (feed) {
-    return function (page_num) {
-        if (Array.isArray(feed)) {
-            return feed.map(uri => `${uri}?paged=${page_num}`);
-        } else {
-            return `${feed}?paged=${page_num}`;
-        }
-    };
+    if (Array.isArray(feed)) {
+        return feed.map(uri => _do_create_wordpress(uri));
+    }
+    return _do_create_wordpress(feed);
 }
 
 exports.create_wordpress_paginator = create_wordpress_paginator;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/formatio": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
     "JSONStream": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
@@ -4603,6 +4612,12 @@
         }
       }
     },
+    "json-date-parser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-date-parser/-/json-date-parser-1.0.1.tgz",
+      "integrity": "sha1-tw60fImPOxZkOtY/+42WIP14T4U=",
+      "dev": true
+    },
     "json-parse-better-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
@@ -4680,6 +4695,12 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
+    },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
     },
     "kebab-case": {
       "version": "1.0.0",
@@ -4917,6 +4938,12 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "lolex": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
+      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "dev": true
     },
     "longest-streak": {
       "version": "2.0.2",
@@ -5468,6 +5495,19 @@
         "regex-not": "1.0.2",
         "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
+      }
+    },
+    "nise": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.2.tgz",
+      "integrity": "sha512-KPKb+wvETBiwb4eTwtR/OsA2+iijXP+VnlSFYJo3EHjm2yjek1NWxHOUQat3i7xNLm1Bm18UA5j5Wor0yO2GtA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "2.0.0",
+        "just-extend": "1.1.27",
+        "lolex": "2.3.2",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
       }
     },
     "node-gyp": {
@@ -6043,6 +6083,23 @@
       "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -6561,6 +6618,16 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "rewire": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-3.0.2.tgz",
+      "integrity": "sha512-ejkkt3qYnsQ38ifc9llAAzuHiGM7kR8N5/mL3aHWgmWwet0OMFcmJB8aTsMV2PBHCWxNVTLCeRfBpEa8X2+1fw==",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0"
+      }
+    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -6588,6 +6655,12 @@
       "requires": {
         "ret": "0.1.15"
       }
+    },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
     },
     "sass-graph": {
       "version": "2.2.4",
@@ -6683,6 +6756,44 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "sinon": {
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.10.tgz",
+      "integrity": "sha512-GxYFgYPhuYY9RXjg6UrEE6ShiaRWM8W8EqaUCRCpqnqKfcyTcfProHZtPeZXiegMfxXKOOQhawTam66gDKVYoQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "2.0.0",
+        "diff": "3.5.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.3.2",
+        "nise": "1.3.2",
+        "supports-color": "5.3.0",
+        "type-detect": "4.0.8"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        },
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+          "dev": true
+        }
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -7216,6 +7327,12 @@
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         }
       }
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "thenify": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -33,9 +33,12 @@
     "chai": "^3.5.0",
     "documentation": "^5.3.5",
     "jshint": "^2.9.5",
+    "json-date-parser": "^1.0.1",
     "mocha": "^4.1.0",
     "mocha-jenkins-reporter": "^0.3.7",
-    "proxyquire": "^1.8.0"
+    "proxyquire": "^1.8.0",
+    "rewire": "^3.0.2",
+    "sinon": "^4.4.10"
   },
   "scripts": {
     "docs:build": "rm -rf docs && documentation build lib/index.js lib/util.js -o docs -f html",

--- a/test/lib/test_files/rss-feeds.json
+++ b/test/lib/test_files/rss-feeds.json
@@ -1,0 +1,139 @@
+{
+    "simple": {
+        "items": [
+            {"pubdate": "2018-04-07T01:21:06.010Z",
+             "link": "http://simple-site.com/article-d",
+             "title": "30 mins ago"},
+            {"pubdate": "2018-04-06T23:51:06.010Z",
+             "link": "http://simple-site.com/article-c",
+             "title": "2 hs ago"},
+            {"pubdate": "2018-04-06T01:51:05.910Z",
+             "link": "http://simple-site.com/article-b",
+             "title": "almost 1 day ago"},
+            {"pubdate": "2018-04-02T01:51:06.010Z",
+             "link": "http://simple-site.com/article-a",
+             "title": "5 days ago"}
+        ],
+        "meta": {}
+    },
+    "simple_2": {
+        "items": [
+            {"pubdate": "2018-04-07T01:39:06.010Z",
+             "link": "https://simple2.com/5",
+             "title": "12 mins ago"},
+            {"pubdate": "2018-04-07T01:26:06.010Z",
+             "link": "https://simple2.com/4",
+             "title": "25 mins ago"},
+            {"pubdate": "2018-04-07T01:11:06.010Z",
+             "link": "https://simple2.com/3",
+             "title": "40 mins ago"},
+            {"pubdate": "2018-04-05T23:51:06.010Z",
+             "link": "https://simple2.com/2",
+             "title": "1 day and 2 hs ago"},
+            {"pubdate": "2018-03-08T01:51:06.010Z",
+             "link": "https://simple2.com/1",
+             "title": "30 days ago"}
+        ],
+        "meta": {}
+    },
+    "A_page_1": {
+        "items": [
+            {"pubdate": "2018-04-07T01:21:06.010Z",
+             "link": "http://my-site.com/1",
+             "title": "30 mins ago"},
+            {"pubdate": "2018-04-06T23:51:06.010Z",
+             "link": "http://my-site.com/2",
+             "title": "2 hs ago"},
+            {"pubdate": "2018-04-06T01:51:05.910Z",
+             "link": "http://my-site.com/3",
+             "title": "almost 1 day ago"},
+            {"pubdate": "2018-04-02T01:51:06.010Z",
+             "link": "http://my-site.com/4",
+             "title": "5 days ago"}
+        ],
+        "meta": {}
+    },
+    "A_page_2": {
+        "items": [
+            {"pubdate": "2018-04-01T23:51:06.010Z",
+             "link": "http://my-site.com/foo",
+             "title": "5 days and 2 hs ago"},
+            {"pubdate": "2018-04-01T17:51:06.010Z",
+             "link": "http://my-site.com/bar",
+             "title": "5 days and 8 hs ago"},
+            {"pubdate": "2018-04-01T13:51:06.010Z",
+             "link": "http://my-site.com/baz",
+             "title": "5 days and 12 hs ago"}
+        ],
+        "meta": {}
+    },
+    "A_page_3": {
+        "items": [
+            {"pubdate": "2018-03-30T22:51:06.010Z",
+             "link": "http://my-site.com/x",
+             "title": "7 days and 3 hs ago"},
+            {"pubdate": "2018-03-30T21:51:06.010Z",
+             "link": "http://my-site.com/y",
+             "title": "7 days and 4 hs ago"},
+            {"pubdate": "2018-03-30T20:51:06.010Z",
+             "link": "http://my-site.com/z",
+             "title": "7 days and 5 hs ago"}
+        ],
+        "meta": {}
+    },
+    "A_page_4": {
+        "items": [],
+        "meta": {}
+    },
+    "B_page_1": {
+        "items": [
+            {"pubdate": "2018-04-06T22:31:06.010Z",
+             "link": "http://another.com/f",
+             "title": "3 hs 20 min ago"},
+            {"pubdate": "2018-04-06T20:06:06.010Z",
+             "link": "http://another.com/e",
+             "title": "5 hs 45 min ago"},
+            {"pubdate": "2018-04-05T22:51:06.010Z",
+             "link": "http://another.com/d",
+             "title": "1 days and 3 hs ago"}
+        ],
+        "meta": {
+            "generator": "https://wordpress.org/"
+        }
+    },
+    "B_page_2": {
+        "items": [
+            {"pubdate": "2018-04-05T18:51:06.010Z",
+             "link": "http://another.com/c",
+             "title": "1 days and 7 hs ago"},
+            {"pubdate": "2018-04-04T13:51:06.010Z",
+             "link": "http://another.com/b",
+             "title": "2 days and 12 hs ago"},
+            {"pubdate": "2018-03-11T01:51:06.010Z",
+             "link": "http://another.com/a",
+             "title": "27 days ago"}
+        ],
+        "meta": {}
+    },
+    "B_page_3": {
+        "items": [],
+        "meta": {}
+    },
+    "dups": {
+        "items": [
+            {"pubdate": "2018-04-07T01:44:06.010Z",
+             "link": "http://feed-dup/one",
+             "title": "7 mins ago"},
+            {"pubdate": "2018-04-07T01:42:06.010Z",
+             "link": "http://feed-dup/two",
+             "title": "9 mins ago"},
+            {"pubdate": "2018-04-07T01:39:06.010Z",
+             "link": "http://feed-dup/one",
+             "title": "12 mins ago, duplicated"},
+            {"pubdate": "2018-04-07T01:33:06.010Z",
+             "link": "http://feed-dup/two",
+             "title": "18 mins ago, duplicated"}
+        ],
+        "meta": {}
+    }
+}

--- a/test/lib/util.test.js
+++ b/test/lib/util.test.js
@@ -1,11 +1,35 @@
 'use strict';
 
 const expect = require('chai').expect;
+const sinon = require('sinon');
 const fs = require('fs');
 const cheerio = require('cheerio');
 
-const util = require('../../lib/util');
+const rewire = require('rewire');
+const util = rewire('../../lib/util');
 const libingester = require('../../lib/index');
+const { jsonDateParser } = require('json-date-parser');
+
+const FAKE_NOW = 1523065866010;  // 2018-04-07T01:51:06.010Z
+
+const _RSS_JSON = fs.readFileSync(__dirname + '/test_files/rss-feeds.json');
+
+const FEEDS = JSON.parse(_RSS_JSON, jsonDateParser);
+
+const FEED_PAGES = [
+    ['http://simple-site.com/rss', FEEDS['simple']],
+    ['https://simple2.com/rss', FEEDS['simple_2']],
+    ['http://feed-with-dups', FEEDS['dups']],
+    ['http://my-site.com/rss', FEEDS['A_page_1']],
+    ['http://my-site.com/rss?paged=1', FEEDS['A_page_1']],
+    ['http://my-site.com/rss?paged=2', FEEDS['A_page_2']],
+    ['http://my-site.com/rss?paged=3', FEEDS['A_page_3']],
+    ['http://my-site.com/rss?paged=4', FEEDS['A_page_4']],
+    ['http://another.com/feed', FEEDS['B_page_1']],
+    ['http://another.com/feed?paged=1', FEEDS['B_page_1']],
+    ['http://another.com/feed?paged=2', FEEDS['B_page_2']],
+    ['http://another.com/feed?paged=3', FEEDS['B_page_3']],
+];
 
 describe('encode_uri', function() {
     it('encodes URIs correctly', function() {
@@ -197,5 +221,134 @@ describe('get_embedded_video_asset', () => {
 
         const video_job_ids = $(videoLinkSelector).map((i, v) => v.attribs['data-libingester-asset-id']).get();
         expect(video_job_ids).to.deep.equal([iframeAsset.asset_id, videoAsset.asset_id]);
+    });
+});
+
+describe('test_fetch_rss_entries', () => {
+    let feed_array;
+    let feed_paginated;
+    let feed_wordpress;
+    let feed_array_paged;
+    let feed_array_paged2;
+    let feed_array_mixed;
+    let feed_array_mixed_wordpress;
+    let fetch_rss_restore;
+    let clock;
+
+    beforeEach(function() {
+        clock = sinon.useFakeTimers(FAKE_NOW);
+        feed_array = ['http://simple-site.com/rss', 'https://simple2.com/rss'];
+        feed_paginated = util.create_wordpress_paginator('http://my-site.com/rss');
+        feed_wordpress = 'http://another.com/feed';
+        feed_array_paged = util.create_wordpress_paginator(['http://my-site.com/rss',
+                                                            'http://another.com/feed']);
+        feed_array_paged2 = [util.create_wordpress_paginator('http://my-site.com/rss'),
+                             util.create_wordpress_paginator('http://another.com/feed')];
+        feed_array_mixed = ['http://simple-site.com/rss',
+                            util.create_wordpress_paginator('http://another.com/feed')];
+        feed_array_mixed_wordpress = ['http://simple-site.com/rss',
+                                      'http://another.com/feed'];
+
+        const stub_fetch =  sinon.stub();
+
+        FEED_PAGES.forEach(([input, output]) => {
+            stub_fetch.withArgs(input).resolves(output);
+        });
+
+        fetch_rss_restore = util.__set__('_fetch_rss_json', stub_fetch);
+    });
+    afterEach(() => {
+        fetch_rss_restore();
+        clock.restore();
+    });
+    it('works with default settings', () => {
+        return util.fetch_rss_entries('http://simple-site.com/rss').then(items => {
+            expect(items.length).to.equal(2);
+        });
+    });
+    it('removes duplicated URLs', () => {
+        return util.fetch_rss_entries('http://feed-with-dups').then(items => {
+            expect(items.length).to.equal(2);
+        });
+    });
+    it('can specify max days old', () => {
+        return util.fetch_rss_entries('http://simple-site.com/rss', Infinity, 2).then(items => {
+            expect(items.length).to.equal(3);
+        });
+    });
+    it('can specify max items', () => {
+        return util.fetch_rss_entries('http://simple-site.com/rss', 2).then(items => {
+            expect(items.length).to.equal(2);
+        });
+    });
+    it('can specify max items and max days old', () => {
+        return util.fetch_rss_entries('http://simple-site.com/rss', 4, 2).then(items => {
+            expect(items.length).to.equal(3);
+        });
+    });
+    it('works with array, default settings', () => {
+        return util.fetch_rss_entries(feed_array).then(items => {
+            expect(items.length).to.equal(5);
+        });
+    });
+    it('can specify max days old, array', () => {
+        return util.fetch_rss_entries(feed_array, Infinity, 2).then(items => {
+            expect(items.length).to.equal(7);
+        });
+    });
+    it('can specify max items and max days old, array', () => {
+        return util.fetch_rss_entries(feed_array, 4, 2).then(items => {
+            expect(items.length).to.equal(4);
+        });
+    });
+    it('can add pagination', () => {
+        return util.fetch_rss_entries(feed_paginated, Infinity, 100).then(items => {
+            expect(items.length).to.equal(10);
+        });
+    });
+    it('can specify max items, pagination', () => {
+        return util.fetch_rss_entries(feed_paginated, 5, 365).then(items => {
+            expect(items.length).to.equal(5);
+        });
+    });
+    it('can specify max days old, pagination', () => {
+        return util.fetch_rss_entries(feed_paginated, 100, 6).then(items => {
+            expect(items.length).to.equal(7);
+        });
+    });
+    it('can add pagination to arrays', () => {
+        return util.fetch_rss_entries(feed_array_paged).then(items => {
+            expect(items.length).to.equal(4);
+        });
+    });
+    it('can add pagination to items in arrays', () => {
+        return util.fetch_rss_entries(feed_array_paged2).then(items => {
+            expect(items.length).to.equal(4);
+        });
+    });
+    it('can autodiscover wordpress pagination', () => {
+        return util.fetch_rss_entries(feed_wordpress, Infinity, 365).then(items => {
+            expect(items.length).to.equal(6);
+        });
+    });
+    it('can mix URIs and paginated in arrays', () => {
+        return util.fetch_rss_entries(feed_array_mixed, Infinity, 365).then(items => {
+            expect(items.length).to.equal(10);
+        });
+    });
+    it('can mix and autodiscover wordpress', () => {
+        return util.fetch_rss_entries(feed_array_mixed_wordpress, Infinity, 365).then(items => {
+            expect(items.length).to.equal(10);
+        });
+    });
+    it('can mix and autodiscover and specify max days old', () => {
+        return util.fetch_rss_entries(feed_array_mixed_wordpress, Infinity, 2).then(items => {
+            expect(items.length).to.equal(7);
+        });
+    });
+    it('can mix and autodiscover and specify max items', () => {
+        return util.fetch_rss_entries(feed_array_mixed_wordpress, 5, 2).then(items => {
+            expect(items.length).to.equal(5);
+        });
     });
 });


### PR DESCRIPTION
Also fix bugs in pagination: arrays respecting MAX_DAYS_OLD only for
the first item.  Added unit tests.  Also added a number of dev
dependencies to stub the test feeds:

- sinon and rewire in combination to stub the _fetch_rss_json()
  private function.

- sinon.useFakeTimers() to stub the global Date object.

- json-date-parser to obtain Date objects when parsing the json file.

https://phabricator.endlessm.com/T21642