### PR TITLE
Unify settings: separate config.js module

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,91 @@
+'use strict';
+
+/** @namespace config */
+
+const fs = require('fs-extra');
+const argv = require('argv-parse');
+
+
+const CLI_OPTIONS = {
+    'config-file': {
+        type: 'string'
+    },
+    'no-tgz': {
+        type: 'boolean'
+    },
+    'path': {
+        type: 'string'
+    },
+    'urls': {
+        type: 'array'
+    },
+};
+
+const _config = {};
+
+
+/**
+ * Unified place to Parse the options.
+ *
+ * The argument passing has the following priority:
+ *
+ *   1. options.argv passed as parameter.
+ *
+ *   2. arguments passed to the command line. If 1. is passed, these
+ *      arguments get fully overriden.
+ *
+ *   3. a JSON config file with options inside. Must be passed in 2.
+ *      or 1. as `--config-file`. If more options are passed, they
+ *      each override the same option if it is declared in the config
+ *      file.
+ *
+ * @param {Object} options [{}] - A dictionary with options
+ * @param {Array} options.argv - An array of arguments. Defaults to
+ *   the command-line arguments passed to the process.
+ *  - '--path' - Use a filesystem path different than the default in the working directory
+ *  - '--no-tgz' - Whether to skip compressing the hatch (see
+ *   {@link Hatch#is_exporting_tgz})
+ *  - '--urls' - Stores an array of URLs that {@link Hatch#get_urls}
+ *    can return.
+ *  - '--config-file' - A JSON config file with options inside. See above.
+ * @memberof config
+ */
+function parse_options(options) {
+    options = options || {};
+
+    const argv_options = options.argv || process.argv.slice(2);
+    const cli_options = argv(CLI_OPTIONS, argv_options);
+
+    let configfile_options = {};
+    if (cli_options['config-file']) {
+        const cf = cli_options['config-file'];
+        configfile_options = fs.readJsonSync(cf);
+    }
+
+    Object.assign(_config, options, configfile_options, cli_options);
+}
+
+exports.parse_options = parse_options;
+
+
+/**
+ *
+ * Get one setting.
+ *
+ * @param {string} setting - The setting name
+ * @returns {any} - The setting value
+ * @memberof config
+ */
+function get_setting(setting) {
+    if (_config) {
+        return _config[setting];
+    }
+}
+
+exports.get_setting = get_setting;
+
+function clean() {
+    Object.keys(_config).forEach(function (key) { delete _config[key]; });
+}
+
+exports.clean = clean;

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,28 +6,13 @@ const crypto = require('crypto');
 const mustache = require('mustache');
 const path = require('path');
 const sass = require('node-sass');
-const argv = require('argv-parse');
 const verify = require('./verify');
+const config = require('./config');
 const { logger } = require('./logging');
 
 const thenify_all = require('thenify-all');
 const fs = thenify_all(require('fs-extra'), {}, ['readFile', 'writeFile', 'readdir', 'copy']);
 const tar = require('tar');
-
-const CLI_OPTIONS = {
-    'config-file': {
-        type: 'string'
-    },
-    'no-tgz': {
-        type: 'boolean'
-    },
-    'path': {
-        type: 'string'
-    },
-    'urls': {
-        type: 'array'
-    },
-};
 
 const EKN_STATIC_TAG = 'EknStaticTag';
 
@@ -1096,32 +1081,13 @@ function is_subset(a, b) {
 /**
  * Creates the hatch and parses arguments.
  *
- * The argument passing has the following priority:
- *
- *   1. options.argv passed to the Hatch constructor.
- *
- *   2. arguments passed to the command line. If 1. is passed, these
- *      arguments get fully overriden.
- *
- *   3. a JSON config file with options inside. Must be passed in
- *      2. or 1. as `--config-file`. If more options are passed, they
- *      each override the same option if it is declared in the config
- *      file.
- *
  * @param {string} name - A name for the ingester
  * @param {string} language - ISO 3166-1 alpha-2 two-letter language code, for
  *   use in generating spelling and stopwords dictionaries for search
- * @param {Object} options - A dictionary with options
- * @param {string} options.path - Use a filesystem path different than
- *    the default in the working directory
- * @param {boolean} options['no-tgz'] - Whether to skip compressing the hatch (see
- *   {@link Hatch#is_exporting_tgz})
- * @param {Array} options.urls - Stores an array of URLs that
- *    get_urls() can return. The ingesters can use this URLs to
- *    reingest a batch of articles.
- * @param {string[]} options.argv - Command-line arguments, defaults to the
- *   command-line arguments passed to the process
- */
+ * @param {Object} options [{}] - A dictionary with options. For a
+ * list of available options see {@link
+ * configparse_options|config.parse_options}
+*/
 class Hatch {
     constructor(name, language, options) {
         this._promises = [];
@@ -1129,7 +1095,7 @@ class Hatch {
         this._failed_assets = [];
         this._videos = [];
 
-        options = this._parse_options(options);
+        config.parse_options(options);
 
         if (!name) {
             throw new Error("ERROR! Hatch name must be specified!");
@@ -1143,32 +1109,11 @@ class Hatch {
 
         this._name = name;
         this._language = language;
-        this._urls = options.urls || null;
-        const _path = `hatch_${this._name.toLowerCase()}_${getTimestamp()}`;
-        this._path = options.path || _path;
-        this._is_exporting_tgz = !options['no-tgz'];
+        this._path = config.get_setting('path') || this._get_default_path();
 
         if (!fs.existsSync(this._path)) {
             fs.mkdirSync(this._path, 0o775);
         }
-    }
-
-    // XXX: This allows us to pass params from SOMA worker
-    //      directly into libingester with minimal changes
-    //      to the actual ingester.
-    _parse_options(options) {
-        options = options || {};
-
-        const argv_options = options.argv || process.argv.slice(2);
-        const cli_options = argv(CLI_OPTIONS, argv_options);
-
-        let configfile_options = {};
-        if (cli_options['config-file']) {
-            const cf = cli_options['config-file'];
-            configfile_options = fs.readJsonSync(cf);
-        }
-
-        return Object.assign(options, configfile_options, cli_options);
     }
 
     /**
@@ -1177,11 +1122,19 @@ class Hatch {
      * @returns {boolean}
      */
     is_exporting_tgz() {
-      return this._is_exporting_tgz;
+        return !config.get_setting('no-tgz');
     }
 
+
+    /**
+     *  Return an array of URLs if passed as settings.
+     *
+     *  The ingesters can use this URLs to reingest a batch of
+     *  articles.
+     * @returns {Array|null}
+     */
     get_urls() {
-        return this._urls;
+        return config.get_setting('urls') || null;
     }
 
     /**
@@ -1197,6 +1150,10 @@ class Hatch {
      * @returns {string}
      */
     get_path() { return this._path; }
+
+    _get_default_path() {
+        return `hatch_${this._name.toLowerCase()}_${getTimestamp()}`;
+    }
 
     _purge_failed_assets() {
         // Cache a list of failed asset ids for later
@@ -1348,8 +1305,8 @@ class Hatch {
             logger.info('hatch: creating hatch tarball...');
 
             // If we only are saving the dir, we return the path
-            if (!this._is_exporting_tgz) {
-              return this._path;
+            if (!this.is_exporting_tgz()) {
+                return this._path;
             }
 
             return this._create_hatch_archive();

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "sinon": "^4.4.10"
   },
   "scripts": {
-    "docs:build": "rm -rf docs && documentation build lib/index.js lib/util.js -o docs -f html",
+    "docs:build": "rm -rf docs && documentation build lib/index.js lib/util.js lib/config.js -o docs -f html",
     "docs:publish": "npm run docs:build && git add -A docs && git commit -m 'Auto commit documentation'",
     "release": "./run_release.sh",
     "test": "./run_tests.sh"

--- a/test/lib/config.test.js
+++ b/test/lib/config.test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const expect = require('chai').expect;
+
+const config = require('../../lib/config');
+
+
+describe('config', function() {
+    beforeEach(() => {
+        config.clean();
+    });
+    afterEach(() => {
+        config.clean();
+    });
+    it('can parse options correctly', function() {
+        const options = { argv: ["--path", "/tmp/mypath",
+                                 "--no-tgz",
+                                 "--urls", "https://foo.com", "https://bar.com"] };
+        config.parse_options(options);
+        expect(config.get_setting('path')).to.equal("/tmp/mypath");
+        expect(config.get_setting('no-tgz')).to.be.true;
+        expect(config.get_setting('urls')).to.have.members(["https://foo.com",
+                                                            "https://bar.com"]);
+    });
+
+    it('can update options', function() {
+        config.parse_options({ argv: ["--path", "/tmp/mypath",
+                                      "--no-tgz"] });
+        expect(config.get_setting('path')).to.equal("/tmp/mypath");
+        expect(config.get_setting('no-tgz')).to.be.true;
+
+        config.parse_options({ argv: ["--path", "/tmp/my-new-path"] });
+        expect(config.get_setting('path')).to.equal("/tmp/my-new-path");
+        expect(config.get_setting('no-tgz')).to.be.true;
+    });
+});

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -4,6 +4,8 @@ const fs = require('fs');
 const expect = require('chai').expect;
 const proxyquire = require('proxyquire');
 
+const config = require('../../lib/config');
+
 const libingester = proxyquire('../../lib/index', {
     './verify': {
         verify_metadata: () => {},
@@ -91,6 +93,12 @@ describe('Hatch', function() {
     });
 
     describe('argv no-tgz option', function() {
+        beforeEach(() => {
+            config.clean();
+        });
+        afterEach(() => {
+            config.clean();
+        });
         it('does not blow up when no-tgz arg is missing', function() {
             // Implicit non-exception
             hatch = new libingester.Hatch("aacd", "en", { argv: ["/some/path"] });
@@ -131,6 +139,12 @@ describe('Hatch', function() {
     });
 
     describe('argv path option', function() {
+        beforeEach(() => {
+            config.clean();
+        });
+        afterEach(() => {
+            config.clean();
+        });
         it('does not blow up when path arg is not there', function() {
             // Implicit non-exception
             hatch = new libingester.Hatch("abcd", "en", { argv: ["--foo", "/some/path"] });
@@ -172,6 +186,12 @@ describe('Hatch', function() {
     });
 
     describe('argv urls option', function() {
+        beforeEach(() => {
+            config.clean();
+        });
+        afterEach(() => {
+            config.clean();
+        });
         it('null when urls arg is missing', function() {
             hatch = new libingester.Hatch("aacd", "en", { argv: ["/some/path"] });
             expect(hatch.get_urls()).to.be.a('null');
@@ -188,9 +208,13 @@ describe('Hatch', function() {
     describe('handles failed assets', () => {
         let expectedError;
         beforeEach(() => {
+            config.clean();
             hatch = new libingester.Hatch("abcd", "en", { argv: ["--no-tgz"] });
             expectedError = new Error('expected error');
             expectedError.stack = '';
+        });
+        afterEach(() => {
+            config.clean();
         });
 
         it('fails if all assets failed', () => {
@@ -279,7 +303,11 @@ describe('Hatch', function() {
 
     describe('builds hierarchy', () => {
         beforeEach(() => {
+            config.clean();
             hatch = new libingester.Hatch("abcd", "en", { argv: ["--no-tgz"] });
+        });
+        afterEach(() => {
+            config.clean();
         });
 
         it('only assigns parent assets the "isToplevel" attribute', () => {


### PR DESCRIPTION
- Refactor settings, now outside the Hatch constructor.
- Move documentation for settings to the new module.
- Tests: Clean settings between runs.

https://phabricator.endlessm.com/T22161