### PR TITLE
util: Move RSS utilities into its own module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,7 @@ function isSubset(a, b) {
  *   use in generating spelling and stopwords dictionaries for search
  * @param {Object} options [{}] - A dictionary with options. For a
  * list of available options see {@link
- * configparse_options|config.parse_options}
+ * #configparseoptions|config.parseOptions}
 */
 class Hatch {
     constructor(name, language, options) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,7 +4,6 @@
 
 const cheerio = require('cheerio');
 const crypto = require('crypto');
-const Feedparser = require('feedparser');
 const parseDataUrl = require('parse-data-url');
 const request = require('request');
 const url = require('url');
@@ -14,6 +13,7 @@ const { logger } = require('./logging');
 const somaDOM = require('./soma_dom');
 const ImageAsset = require('./asset/imageAsset');
 const VideoAsset = require('./asset/videoAsset');
+const rss = require('./util/rss');
 
 const USER_AGENT = 'libingester';
 
@@ -365,199 +365,21 @@ function getIngestionLimits(maxItems = Infinity, maxDaysOld = 1) {
     };
 }
 
-function _fetchRssPage(feed, page, items, allLinks, maxItems, oldestDate) {
-    let isPaginated = false;
-    let feedUrl;
-
-    let feedObj = feed;
-    if (Array.isArray(feed)) {
-        feedObj = feed[0];
-    }
-
-    if (typeof feedObj === 'function') {
-        isPaginated = true;
-        feedUrl = feedObj(page);
-    } else {
-        feedUrl = feedObj;
-    }
-
-    if (!feedUrl) {
-        return items;
-    }
-
-    logger.debug(`Fetching RSS ${feedUrl}`);
-
-    return _fetchRssJsonWithRetry(feedUrl).then(feedJson => {
-        const recentEnoughItems = feedJson.items
-              .filter(item => item.pubdate >= oldestDate);
-
-        const limitedItems = [];
-        recentEnoughItems.slice(0, maxItems - items.length).forEach(item => {
-            if (!allLinks.has(item.link)) {
-                limitedItems.push(item);
-                allLinks.add(item.link);
-            }
-        });
-
-        const newItems = items.concat(limitedItems);
-
-        // If we've run into articles which are too old, or we've hit the max
-        // number of items, cease crawling
-        const doneCrawling = (feedJson.items.length === 0 ||
-                              limitedItems.length < feedJson.items.length);
-
-        if ((typeof feedObj !== 'function') && _isWordpressFeed(feedJson)) {
-            logger.debug('Wordpress feed found, adding pagination');
-            isPaginated = true;
-            const newFeed = _doCreateWordpress(feedObj);
-            if (Array.isArray(feed)) {
-                feed.shift();
-                feed = [newFeed].concat(feed);
-            } else {
-                feed = newFeed;
-            }
-        }
-
-        const _continue = Array.isArray(feed) ||
-              (!doneCrawling && isPaginated);
-
-        if (!_continue) {
-            return newItems;
-        }
-
-        let newPage;
-        if (doneCrawling && isPaginated && Array.isArray(feed)) {
-            feed.shift();
-            newPage = 1;
-        } else {
-            if (isPaginated) {
-                newPage = page + 1;
-            } else if (Array.isArray(feed)) {
-                feed.shift();
-                newPage = 1;
-            }
-        }
-        return _fetchRssPage(feed, newPage, newItems, allLinks, maxItems, oldestDate);
-    });
-}
-
-/**
- * A utility for fetching entries from an RSS feed for further processing.
- *
- * The `max_items` and `max_days_old` parameters can be overridden by the
- * `LIBINGESTER_MAX_ITEMS` and `LIBINGESTER_MAX_DAYS_OLD` environment
- * variables, respectively.
- *
- * @param {string|Array|Function} feed - URL of RSS feed to read, or an array of
- *   URLs of RSS feeds to read, or a paginator function that returns a URL given
- *   a page number
- * @param {number} [max_items=Infinity] - Maximum number of entries to return
- * @param {number} [max_days_old=1] - Maximum age of entries returned, in days
- * @returns {Promise<Object[]>} - Array of RSS feed entries
- * @memberof util
- */
-function fetchRssEntries(feed, max_items = Infinity, max_days_old = 1) {
-    // Allow environment variables to override this
-    const limits = getIngestionLimits(max_items, max_days_old);
-
-    return _fetchRssPage(feed, 1, [], new Set(), limits.max_items,
-                         limits.oldest_date);
-}
-
-function _fetchRssJson(feedUrl) {
-    return new Promise((resolve, reject) => {
-        const req = request.get(feedUrl);
-        const parser = new Feedparser();
-
-        req.on('error', reject);
-        parser.on('error', reject);
-
-        const feedData = { items: [] };
-
-        parser.on('meta', meta => {
-            feedData.meta = meta;
-        });
-
-        parser.on('data', article => {
-            feedData.items.push(article);
-        });
-
-        parser.on('end', () => resolve(feedData));
-
-        req.pipe(parser);
-    });
-}
-
-function _isWordpressFeed(feedJson) {
-    const hasGenerator = feedJson.meta.generator &&
-          feedJson.meta.generator.startsWith('https://wordpress.org/');
-    const hasXmlns = feedJson.meta['rss:site'] &&
-          feedJson.meta['rss:site']['@'] &&
-          feedJson.meta['rss:site']['@']['xmlns'] &&
-          feedJson.meta['rss:site']['@']['xmlns'].startsWith('com-wordpress');
-
-    return hasGenerator || hasXmlns;
-}
-
-function _fetchRssJsonWithRetry(feedUrl, attempt = 1) {
-    const maxRetries = parseInt(config.get_setting('max-retries'), 10);
-    const retryBackoffDelay = parseInt(config.get_setting('retry-backoff-delay'), 10);
-
-    return _fetchRssJson(feedUrl).catch(err => {
-        if (attempt > maxRetries) {
-            logger.warn(`Max retries (${maxRetries}) exceeded!`);
-            throw err;
-        }
-
-        const shouldRetry = (err.message.match('Unexpected end') ||
-                             err.message.match('Not a feed'));
-        if (shouldRetry) {
-            const timeout = Math.pow(2, attempt) * retryBackoffDelay;
-            logger.debug(`Delaying execution of ${feedUrl} by ${timeout}`);
-
-            return delayExecution(timeout).then(() => {
-                return _fetchRssJsonWithRetry(feedUrl, attempt + 1);
-            });
-        }
-
-        // We reach here if unexpected error
-        throw err;
-    });
-}
-
-function _doCreateWordpress(feed) {
-    return function (pageNum) {
-        return `${feed}?paged=${pageNum}`;
-    };
-}
-
-/**
- * A utility to create a pagination function for Wordpress-generated feeds,
- * since they are so common. Make sure to verify that your feed is generated by
- * Wordpress before using this!
- * @param {string|Array} feed - The URL of the RSS feed (first page), or an
- *   array of URLs of RSS feeds
- * @returns {function} - A paginator function that can be passed to
- *   {@link util.fetchRssEntries|util.fetchRssEntries}
- * @memberof util
- */
-function createWordpressPaginator(feed) {
-    if (Array.isArray(feed)) {
-        return feed.map(uri => _doCreateWordpress(uri));
-    }
-    return _doCreateWordpress(feed);
-}
 
 module.exports = {
-    create_wordpress_paginator: createWordpressPaginator,
     download_image: downloadImage,
     download_img: downloadImageFromImgTag,
     download_youtube_thumbnail: downloadYoutubeThumbnail,
     encode_uri: encodeUri,
     fetch_html: fetchHtml,
-    fetch_rss_entries: fetchRssEntries,
     get_doc_base_uri: getDocBaseUri,
     get_embedded_video_asset: getEmbeddedVideoAsset,
     get_ingestion_limits: getIngestionLimits,
+    getIngestionLimits: getIngestionLimits,
     set_user_agent: setUserAgent,
+    rss: rss,
+
+    // For backwards compatibility:
+    create_wordpress_paginator: rss.create_wordpress_paginator,
+    fetch_rss_entries: rss.fetch_rss_entries,
 };

--- a/test/lib/util.test.js
+++ b/test/lib/util.test.js
@@ -1,36 +1,11 @@
 'use strict';
 
 const expect = require('chai').expect;
-const sinon = require('sinon');
 const fs = require('fs');
 const cheerio = require('cheerio');
 
-const rewire = require('rewire');
-const util = rewire('../../lib/util');
+const util = require('../../lib/util');
 const libingester = require('../../lib/index');
-const { jsonDateParser } = require('json-date-parser');
-
-// 2018-04-07T01:51:06.010Z
-const FAKE_NOW = 1523065866010;
-
-const _RSS_JSON = fs.readFileSync(`${__dirname}/test_files/rss-feeds.json`);
-
-const FEEDS = JSON.parse(_RSS_JSON, jsonDateParser);
-
-const FEED_PAGES = [
-    [ 'http://simple-site.com/rss', FEEDS['simple'] ],
-    [ 'https://simple2.com/rss', FEEDS['simple_2'] ],
-    [ 'http://feed-with-dups', FEEDS['dups'] ],
-    [ 'http://my-site.com/rss', FEEDS['A_page_1'] ],
-    [ 'http://my-site.com/rss?paged=1', FEEDS['A_page_1'] ],
-    [ 'http://my-site.com/rss?paged=2', FEEDS['A_page_2'] ],
-    [ 'http://my-site.com/rss?paged=3', FEEDS['A_page_3'] ],
-    [ 'http://my-site.com/rss?paged=4', FEEDS['A_page_4'] ],
-    [ 'http://another.com/feed', FEEDS['B_page_1'] ],
-    [ 'http://another.com/feed?paged=1', FEEDS['B_page_1'] ],
-    [ 'http://another.com/feed?paged=2', FEEDS['B_page_2'] ],
-    [ 'http://another.com/feed?paged=3', FEEDS['B_page_3'] ],
-];
 
 describe('encode_uri', () => {
     it('encodes URIs correctly', () => {
@@ -226,136 +201,5 @@ describe('get_embedded_video_asset', () => {
         }).get();
 
         expect(videoJobIds).to.deep.equal([ iframeAsset.asset_id, videoAsset.asset_id ]);
-    });
-});
-
-describe('test_fetch_rss_entries', () => {
-    let feedArray;
-    let feedPaginated;
-    let feedWordpress;
-    let feedArrayPaged;
-    let feedArrayPaged2;
-    let feedArrayMixed;
-    let feedArrayMixedWordpress;
-    let fetchRssRestore;
-    let clock;
-
-    beforeEach(() => {
-        clock = sinon.useFakeTimers(FAKE_NOW);
-        feedArray = [ 'http://simple-site.com/rss', 'https://simple2.com/rss' ];
-        feedPaginated = util.create_wordpress_paginator('http://my-site.com/rss');
-        feedWordpress = 'http://another.com/feed';
-        feedArrayPaged = util.create_wordpress_paginator([ 'http://my-site.com/rss',
-                                                           'http://another.com/feed' ]);
-        feedArrayPaged2 = [ util.create_wordpress_paginator('http://my-site.com/rss'),
-                            util.create_wordpress_paginator('http://another.com/feed') ];
-        feedArrayMixed = [ 'http://simple-site.com/rss',
-                           util.create_wordpress_paginator('http://another.com/feed') ];
-        feedArrayMixedWordpress = [ 'http://simple-site.com/rss',
-                                    'http://another.com/feed' ];
-
-        const stubFetch = sinon.stub();
-
-        FEED_PAGES.forEach(([ input, output ]) => {
-            stubFetch.withArgs(input).resolves(output);
-        });
-
-        fetchRssRestore = util.__set__('_fetchRssJson', stubFetch);
-    });
-    afterEach(() => {
-        fetchRssRestore();
-        clock.restore();
-    });
-    it('works with default settings', () => {
-        return util.fetch_rss_entries('http://simple-site.com/rss').then(items => {
-            expect(items.length).to.equal(2);
-            expect(items[0]).to.include.keys('link');
-            expect(items[1]).to.include.keys('link');
-        });
-    });
-    it('removes duplicated URLs', () => {
-        return util.fetch_rss_entries('http://feed-with-dups').then(items => {
-            expect(items.length).to.equal(2);
-        });
-    });
-    it('can specify max days old', () => {
-        return util.fetch_rss_entries('http://simple-site.com/rss', Infinity, 2).then(items => {
-            expect(items.length).to.equal(3);
-        });
-    });
-    it('can specify max items', () => {
-        return util.fetch_rss_entries('http://simple-site.com/rss', 2).then(items => {
-            expect(items.length).to.equal(2);
-        });
-    });
-    it('can specify max items and max days old', () => {
-        return util.fetch_rss_entries('http://simple-site.com/rss', 4, 2).then(items => {
-            expect(items.length).to.equal(3);
-        });
-    });
-    it('works with array, default settings', () => {
-        return util.fetch_rss_entries(feedArray).then(items => {
-            expect(items.length).to.equal(5);
-        });
-    });
-    it('can specify max days old, array', () => {
-        return util.fetch_rss_entries(feedArray, Infinity, 2).then(items => {
-            expect(items.length).to.equal(7);
-        });
-    });
-    it('can specify max items and max days old, array', () => {
-        return util.fetch_rss_entries(feedArray, 4, 2).then(items => {
-            expect(items.length).to.equal(4);
-        });
-    });
-    it('can add pagination', () => {
-        return util.fetch_rss_entries(feedPaginated, Infinity, 100).then(items => {
-            expect(items.length).to.equal(10);
-        });
-    });
-    it('can specify max items, pagination', () => {
-        return util.fetch_rss_entries(feedPaginated, 5, 365).then(items => {
-            expect(items.length).to.equal(5);
-        });
-    });
-    it('can specify max days old, pagination', () => {
-        return util.fetch_rss_entries(feedPaginated, 100, 6).then(items => {
-            expect(items.length).to.equal(7);
-        });
-    });
-    it('can add pagination to arrays', () => {
-        return util.fetch_rss_entries(feedArrayPaged).then(items => {
-            expect(items.length).to.equal(4);
-        });
-    });
-    it('can add pagination to items in arrays', () => {
-        return util.fetch_rss_entries(feedArrayPaged2).then(items => {
-            expect(items.length).to.equal(4);
-        });
-    });
-    it('can autodiscover wordpress pagination', () => {
-        return util.fetch_rss_entries(feedWordpress, Infinity, 365).then(items => {
-            expect(items.length).to.equal(6);
-        });
-    });
-    it('can mix URIs and paginated in arrays', () => {
-        return util.fetch_rss_entries(feedArrayMixed, Infinity, 365).then(items => {
-            expect(items.length).to.equal(10);
-        });
-    });
-    it('can mix and autodiscover wordpress', () => {
-        return util.fetch_rss_entries(feedArrayMixedWordpress, Infinity, 365).then(items => {
-            expect(items.length).to.equal(10);
-        });
-    });
-    it('can mix and autodiscover and specify max days old', () => {
-        return util.fetch_rss_entries(feedArrayMixedWordpress, Infinity, 2).then(items => {
-            expect(items.length).to.equal(7);
-        });
-    });
-    it('can mix and autodiscover and specify max items', () => {
-        return util.fetch_rss_entries(feedArrayMixedWordpress, 5, 2).then(items => {
-            expect(items.length).to.equal(5);
-        });
     });
 });

--- a/test/lib/util/rss.test.js
+++ b/test/lib/util/rss.test.js
@@ -1,0 +1,160 @@
+const expect = require('chai').expect;
+const fs = require('fs');
+const { jsonDateParser } = require('json-date-parser');
+const rewire = require('rewire');
+const sinon = require('sinon');
+
+const rss = rewire('../../../lib/util/rss');
+
+// 2018-04-07T01:51:06.010Z
+const FAKE_NOW = 1523065866010;
+
+const _RSS_JSON = fs.readFileSync(`${__dirname}/../test_files/rss-feeds.json`);
+
+const FEEDS = JSON.parse(_RSS_JSON, jsonDateParser);
+
+const FEED_PAGES = [
+    [ 'http://simple-site.com/rss', FEEDS['simple'] ],
+    [ 'https://simple2.com/rss', FEEDS['simple_2'] ],
+    [ 'http://feed-with-dups', FEEDS['dups'] ],
+    [ 'http://my-site.com/rss', FEEDS['A_page_1'] ],
+    [ 'http://my-site.com/rss?paged=1', FEEDS['A_page_1'] ],
+    [ 'http://my-site.com/rss?paged=2', FEEDS['A_page_2'] ],
+    [ 'http://my-site.com/rss?paged=3', FEEDS['A_page_3'] ],
+    [ 'http://my-site.com/rss?paged=4', FEEDS['A_page_4'] ],
+    [ 'http://another.com/feed', FEEDS['B_page_1'] ],
+    [ 'http://another.com/feed?paged=1', FEEDS['B_page_1'] ],
+    [ 'http://another.com/feed?paged=2', FEEDS['B_page_2'] ],
+    [ 'http://another.com/feed?paged=3', FEEDS['B_page_3'] ],
+];
+
+describe('test_fetch_rss_entries', () => {
+    let feedArray;
+    let feedPaginated;
+    let feedWordpress;
+    let feedArrayPaged;
+    let feedArrayPaged2;
+    let feedArrayMixed;
+    let feedArrayMixedWordpress;
+    let fetchRssRestore;
+    let clock;
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers(FAKE_NOW);
+        feedArray = [ 'http://simple-site.com/rss', 'https://simple2.com/rss' ];
+        feedPaginated = rss.create_wordpress_paginator('http://my-site.com/rss');
+        feedWordpress = 'http://another.com/feed';
+        feedArrayPaged = rss.create_wordpress_paginator([ 'http://my-site.com/rss',
+                                                           'http://another.com/feed' ]);
+        feedArrayPaged2 = [ rss.create_wordpress_paginator('http://my-site.com/rss'),
+                            rss.create_wordpress_paginator('http://another.com/feed') ];
+        feedArrayMixed = [ 'http://simple-site.com/rss',
+                           rss.create_wordpress_paginator('http://another.com/feed') ];
+        feedArrayMixedWordpress = [ 'http://simple-site.com/rss',
+                                    'http://another.com/feed' ];
+
+        const stubFetch = sinon.stub();
+
+        FEED_PAGES.forEach(([ input, output ]) => {
+            stubFetch.withArgs(input).resolves(output);
+        });
+
+        fetchRssRestore = rss.__set__('_fetchRssJson', stubFetch);
+    });
+    afterEach(() => {
+        fetchRssRestore();
+        clock.restore();
+    });
+    it('works with default settings', () => {
+        return rss.fetch_rss_entries('http://simple-site.com/rss').then(items => {
+            expect(items.length).to.equal(2);
+            expect(items[0]).to.include.keys('link');
+            expect(items[1]).to.include.keys('link');
+        });
+    });
+    it('removes duplicated URLs', () => {
+        return rss.fetch_rss_entries('http://feed-with-dups').then(items => {
+            expect(items.length).to.equal(2);
+        });
+    });
+    it('can specify max days old', () => {
+        return rss.fetch_rss_entries('http://simple-site.com/rss', Infinity, 2).then(items => {
+            expect(items.length).to.equal(3);
+        });
+    });
+    it('can specify max items', () => {
+        return rss.fetch_rss_entries('http://simple-site.com/rss', 2).then(items => {
+            expect(items.length).to.equal(2);
+        });
+    });
+    it('can specify max items and max days old', () => {
+        return rss.fetch_rss_entries('http://simple-site.com/rss', 4, 2).then(items => {
+            expect(items.length).to.equal(3);
+        });
+    });
+    it('works with array, default settings', () => {
+        return rss.fetch_rss_entries(feedArray).then(items => {
+            expect(items.length).to.equal(5);
+        });
+    });
+    it('can specify max days old, array', () => {
+        return rss.fetch_rss_entries(feedArray, Infinity, 2).then(items => {
+            expect(items.length).to.equal(7);
+        });
+    });
+    it('can specify max items and max days old, array', () => {
+        return rss.fetch_rss_entries(feedArray, 4, 2).then(items => {
+            expect(items.length).to.equal(4);
+        });
+    });
+    it('can add pagination', () => {
+        return rss.fetch_rss_entries(feedPaginated, Infinity, 100).then(items => {
+            expect(items.length).to.equal(10);
+        });
+    });
+    it('can specify max items, pagination', () => {
+        return rss.fetch_rss_entries(feedPaginated, 5, 365).then(items => {
+            expect(items.length).to.equal(5);
+        });
+    });
+    it('can specify max days old, pagination', () => {
+        return rss.fetch_rss_entries(feedPaginated, 100, 6).then(items => {
+            expect(items.length).to.equal(7);
+        });
+    });
+    it('can add pagination to arrays', () => {
+        return rss.fetch_rss_entries(feedArrayPaged).then(items => {
+            expect(items.length).to.equal(4);
+        });
+    });
+    it('can add pagination to items in arrays', () => {
+        return rss.fetch_rss_entries(feedArrayPaged2).then(items => {
+            expect(items.length).to.equal(4);
+        });
+    });
+    it('can autodiscover wordpress pagination', () => {
+        return rss.fetch_rss_entries(feedWordpress, Infinity, 365).then(items => {
+            expect(items.length).to.equal(6);
+        });
+    });
+    it('can mix URIs and paginated in arrays', () => {
+        return rss.fetch_rss_entries(feedArrayMixed, Infinity, 365).then(items => {
+            expect(items.length).to.equal(10);
+        });
+    });
+    it('can mix and autodiscover wordpress', () => {
+        return rss.fetch_rss_entries(feedArrayMixedWordpress, Infinity, 365).then(items => {
+            expect(items.length).to.equal(10);
+        });
+    });
+    it('can mix and autodiscover and specify max days old', () => {
+        return rss.fetch_rss_entries(feedArrayMixedWordpress, Infinity, 2).then(items => {
+            expect(items.length).to.equal(7);
+        });
+    });
+    it('can mix and autodiscover and specify max items', () => {
+        return rss.fetch_rss_entries(feedArrayMixedWordpress, 5, 2).then(items => {
+            expect(items.length).to.equal(5);
+        });
+    });
+});


### PR DESCRIPTION
In preparation to add more utility functions.

- Tests and docstrings were adapted accordingly
- Preserve API by importing the RSS functions from lib/util .