### PR TITLE
config: Change behaviour of settings passed to Hatch

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -44,13 +44,10 @@ const _config = {};
  *
  *   1. options.argv passed as parameter.
  *
- *   2. arguments passed to the command line. If 1. is passed, these
- *      arguments get fully overriden.
+ *   2. Arguments passed to the command line.
  *
- *   3. a JSON config file with options inside. Must be passed in 2.
- *      or 1. as `--config-file`. If more options are passed, they
- *      each override the same option if it is declared in the config
- *      file.
+ *   3. Options inside a JSON config file. Must be passed in 2. or
+ *      1. as `--config-file FILENAME`.
  *
  * @param {Object} options [{}] - A dictionary with options
  * @param {Array} options.argv - An array of arguments. Defaults to
@@ -64,8 +61,8 @@ const _config = {};
  * @memberof config
  */
 function parse_options(options = {}) {
-    const argvOptions = options.argv || process.argv.slice(2);
-    const cliOptions = argv(CLI_OPTIONS, argvOptions);
+    const cliOptions = Object.assign(argv(CLI_OPTIONS, process.argv.slice(2)),
+                                     argv(CLI_OPTIONS, options.argv));
 
     let configFileOptions = {};
     if (cliOptions['config-file']) {

--- a/test/lib/config.test.js
+++ b/test/lib/config.test.js
@@ -7,11 +7,15 @@ const config = require('../../lib/config');
 
 
 describe('config', () => {
+    let processArgvRestore;
+
     beforeEach(() => {
         config.clean();
+        processArgvRestore = process.argv;
     });
     afterEach(() => {
         config.clean();
+        process.argv = processArgvRestore;
     });
     it('can parse options correctly', () => {
         const options = { argv: [ '--path', '/tmp/mypath',
@@ -43,5 +47,20 @@ describe('config', () => {
                                        '--retry-backoff-delay', '1000' ] });
         expect(config.get_setting('max-retries')).to.equal('10');
         expect(config.get_setting('retry-backoff-delay')).to.equal('1000');
+    });
+
+    it('can pass command line arguments', () => {
+        process.argv = [ 'node', 'my-ingester', '--path', '/tmp/mypath' ];
+        config.parse_options();
+        expect(config.get_setting('path')).to.equal('/tmp/mypath');
+    });
+
+    it('updates command line arguments', () => {
+        process.argv = [ 'node', 'my-ingester', '--path', '/tmp/mypath',
+                         '--no-tgz' ];
+        const options = { argv: [ '--path', './myNewPath' ] };
+        config.parse_options(options);
+        expect(config.get_setting('path')).to.equal('./myNewPath');
+        expect(config.get_setting('no-tgz')).to.be.true;
     });
 });


### PR DESCRIPTION
Merge the options passed to the Hatch constructor with the options
passed in the command line.

The original behaviour was to fully override the command line options
with the options passed to the Hatch constructor.

Added tests for command line options.  The config documentation is now
a bit easier to read.

https://phabricator.endlessm.com/T22232