### PR TITLE
util_download_image(): Improve check for content-type

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -9,6 +9,7 @@ const Feedparser = require('feedparser');
 const parseDataUrl = require('parse-data-url');
 const request = require('request');
 const url = require('url');
+const imageType = require('image-type');
 
 const config = require('./config');
 const { logger } = require('./logging');
@@ -234,10 +235,15 @@ function download_image(uri) {
                             `status code ${response.statusCode}`);
         }
 
-        const contentType = response.headers['content-type'];
+        let contentType = response.headers['content-type'];
         if (contentType.match(/^image/i) === null) {
-            throw new Error(`Request for image ${encodedUri} resulted in a ` +
-                            `non-image: ${contentType}`);
+            const imageTypeFromContent = imageType(response.body);
+            if (imageTypeFromContent) {
+                contentType = imageTypeFromContent.mime;
+            } else {
+                throw new Error(`Request for image ${encodedUri} resulted in a ` +
+                                `non-image: ${contentType}`);
+            }
         }
 
         asset.set_image_data(contentType, response.body);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4116,6 +4116,21 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
+    "image-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/image-type/-/image-type-3.0.0.tgz",
+      "integrity": "sha1-FQKvMTX5BuEiyHfDHpSve3qRRsU=",
+      "requires": {
+        "file-type": "4.4.0"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
+          "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU="
+        }
+      }
+    },
     "in-publish": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "feedparser": "^2.2.0",
     "file-type": "^6.1.0",
     "fs-extra": "^2.0.0",
+    "image-type": "^3.0.0",
     "mustache": "^2.3.0",
     "node-sass": "^4.5.3",
     "parse-data-url": "^0.1.4",


### PR DESCRIPTION
If by looking at the content-type returned by the server fails to
identify an image, try check if it's an image by looking at the
content.

Adds a new dependency lib, image-type.

https://phabricator.endlessm.com/T22412