### PR TITLE
dictionaryAsset, galleryImageArticle: Fix path to data

### DIFF
--- a/lib/asset/dictionaryAsset.js
+++ b/lib/asset/dictionaryAsset.js
@@ -70,10 +70,12 @@ class DictionaryAsset extends BaseAsset {
             };
         }
 
-        const templatePath = path.join(__dirname, '..', 'data/assets/dictionary-article.mst');
+        const templatePath = path.join(__dirname, '..', '..',
+                                       'data/assets/dictionary-article.mst');
         const template = fs.readFileSync(templatePath, 'utf8');
 
-        const dictionaryStylesheet = path.join(__dirname, '..', 'data/assets/news-stylesheet.scss');
+        const dictionaryStylesheet = path.join(__dirname, '..', '..',
+                                               'data/assets/news-stylesheet.scss');
 
         const sassOptions = {
             outputStyle: 'compressed',

--- a/lib/asset/galleryImageArticle.js
+++ b/lib/asset/galleryImageArticle.js
@@ -84,11 +84,12 @@ class GalleryImageArticle extends BaseAsset {
     }
 
     render() {
-        const templatePath = path.join(__dirname, '..', 'data/assets/gallery-image-article.mst');
+        const templatePath = path.join(__dirname, '..', '..',
+                                       'data/assets/gallery-image-article.mst');
         const template = fs.readFileSync(templatePath, 'utf8');
 
-        const galleryImageStylesheet = path.join(__dirname,
-                                                 '..', 'data/assets/gallery-image-stylesheet.scss');
+        const galleryImageStylesheet = path.join(__dirname, '..', '..',
+                                                 'data/assets/gallery-image-stylesheet.scss');
 
         let stylesheet;
         if (this._custom_scss) {


### PR DESCRIPTION
Fix the path to the template file and stylesheet file in these assets.
This was broken in the big refactor.

https://phabricator.endlessm.com/T22462