### PR TITLE
util: Add new utils fetch_news_article(), fetch_blog_article()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -317,6 +317,23 @@ class Hatch {
     }
 
     /**
+     * Explicitly save `asset` as failed.
+     * @param {BaseAsset} asset
+     */
+    save_failed_asset(asset) {
+        this._assets.push(asset);
+        this._failed_assets.push(asset);
+    }
+
+    /**
+     * Check if `asset` has failed.
+     * @param {BaseAsset} asset
+     */
+    has_failed_asset(asset) {
+        return this._failed_assets.includes(asset);
+    }
+
+    /**
      * Copies the generated hatch directory to `directory`. This can be used
      * for automating the ingestion of content.
      * @param {string} directory - A path

--- a/lib/util.js
+++ b/lib/util.js
@@ -14,7 +14,9 @@ const imageType = require('image-type');
 const config = require('./config');
 const { logger } = require('./logging');
 const somaDOM = require('./soma_dom');
+const BlogArticle = require('./asset/blogArticle');
 const ImageAsset = require('./asset/imageAsset');
+const NewsArticle = require('./asset/newsArticle');
 const VideoAsset = require('./asset/videoAsset');
 
 const USER_AGENT = 'libingester';
@@ -149,6 +151,58 @@ function fetch_html(uri, encoding) {
         }
         return cheerio.load(body);
     });
+}
+
+async function _fetch_article(hatch, uri, encoding, Article) {
+    const asset = new Article();
+    let $;
+    try {
+        $ = await fetch_html(uri, encoding);
+    } catch (error) {
+        if (error.message.includes('non-successful status code')) {
+            logger.error(error);
+            hatch.save_failed_asset(asset);
+        } else {
+            throw error;
+        }
+    }
+    return { $, asset };
+}
+
+/**
+ * Returns a DOM object and a NewsArticle corresponding to the URI
+ * provided.  If fetching the DOM fails, the NewsArticle is marked as
+ * failed in the hatch.
+ *
+ * @param {Hatch} hatch - If the asset fails it will be saved as
+ *   failed in this Hatch.
+ * @param {string} uri - URI to load
+ * @param {string} [encoding] - A text encoding, overriding the one
+ *   specified by @uri
+ * @returns {Promise<Object>} - a DOM object constructed from the HTML
+ *   at @uri, and a {@link NewsArticle}
+ * @memberof util
+ */
+function fetch_news_article(hatch, uri, encoding) {
+    return _fetch_article(hatch, uri, encoding, NewsArticle);
+}
+
+/**
+ * Returns a DOM object and a BlogArticle corresponding to the URI
+ * provided.  If fetching the DOM fails, the BlogArticle is marked as
+ * failed in the hatch.
+ *
+ * @param {Hatch} hatch - If the asset fails it will be saved as
+ *   failed in this Hatch.
+ * @param {string} uri - URI to load
+ * @param {string} [encoding] - A text encoding, overriding the one
+ *   specified by @uri
+ * @returns {Promise<Object>} - a DOM object constructed from the HTML
+ *   at @uri, and a {@link BlogArticle}
+ * @memberof util
+ */
+function fetch_blog_article(hatch, uri, encoding) {
+    return _fetch_article(hatch, uri, encoding, BlogArticle);
 }
 
 /**
@@ -572,7 +626,9 @@ module.exports = {
     download_img,
     download_youtube_thumbnail,
     encode_uri,
+    fetch_blog_article,
     fetch_html,
+    fetch_news_article,
     fetch_rss_entries,
     get_doc_base_uri,
     get_embedded_video_asset,


### PR DESCRIPTION
To handle HTTP response errors and mark the Article assets
corresponding to the failing URL as failed.  This way the assets are
accounted in the % of failed assets.  Typical usage is:

    function ingest_article(hatch, uri) {
        return libingester.util.fetch_news_article(hatch, uri).then(({ $, asset }) => {
            if (asset.has_failed()) {
                return;
            }
            // normal article ingestion
        });
    }

https://phabricator.endlessm.com/T22195