### PR TITLE
README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,15 @@ LGPL v2.1
 
 - Running tests:
  ```
- $ npm test # or ./run_tests.sh
+ $ npm test
  ```
 
 ### Linting (eslint):
  ```
- $ sudo npm install -g eslint
+ $ npm install -g eslint
+ $ npm install -g eslint-config-node
+ $ npm install -g babel-eslint
+ $ npm install -g eslint-plugin-import
 
  $ # Only show errors
  $ eslint --quiet .


### PR DESCRIPTION
- Don't require sudo for eslint.

- Document required eslint modules. Another option is add eslint and
  the related eslint modules as dev dependencies.

- Showing one way to run the tests is enough.