### PR TITLE
util: download_img, use Cheerio wrap

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -402,8 +402,7 @@ function download_img($img, baseUri = '') {
     $img.attr(somaDOM.Hint.Tag, somaDOM.Hint.ImportantImage);
 
     const linkWrapper = cheerio(`<a ${somaDOM.Widget.Tag}="${somaDOM.Widget.ImageLink}"></a>`);
-    linkWrapper.append($img.clone());
-    $img.replaceWith(linkWrapper);
+    $img.wrap(linkWrapper);
 
     return asset;
 }


### PR DESCRIPTION
To avoid cloning the image element as it can conflict with the
cleanup.