### PR TITLE
Don't save the title in the manifest

### DIFF
--- a/lib/asset/baseAsset.js
+++ b/lib/asset/baseAsset.js
@@ -233,7 +233,6 @@ class BaseAsset {
         return {
             asset_id: this.asset_id,
             uri: this._canonical_uri,
-            title: this._title,
             dependent_asset_ids: this.get_dependent_assets(),
         };
     }


### PR DESCRIPTION
This is going to break compatibility with the current hatch structure.
But it's really needed to save a considerable amount of memory on big
ingesters (encyclopedia).

FTR, the title from the manifest file is not actually used in SOMA.