### PR TITLE
Ingester: log total / failed, and exit accordingly

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -67,7 +67,17 @@ class Config {
                 type: 'boolean',
                 default: false,
             })
-            .group(['path', 'tgz'], 'Output:')
+            .option('hatch-fail-rate-threshold', {
+                type: 'number',
+                default: 0.9,
+            })
+            .check(argv => {
+                if (argv.hatchFailRateThreshold < 0 || argv.hatchFailRateThreshold > 1) {
+                    throw (new Error('--hatch-fail-rate-threshold should be between 0 and 1'));
+                }
+                return true;
+            })
+            .group(['path', 'tgz', 'hatch-fail-rate-threshold'], 'Output:')
             .option('urls', {
                 type: 'array',
             })

--- a/lib/ingester.js
+++ b/lib/ingester.js
@@ -9,6 +9,7 @@ const { ImplementationError } = require('./errors');
 class Ingester {
     constructor (ingesterPath = null) {
         this.ingesterPath = ingesterPath;
+        this.assetsCount = { 'total': 0, 'failed': 0 };
 
         if (!this.ingesterPath) {
             this._name = 'libingester';
@@ -36,27 +37,46 @@ class Ingester {
         return 'en';
     }
 
+    getIngestionStatus () {
+        const failedProportion = this.assetsCount.failed / this.assetsCount.total;
+        if (failedProportion === 0) {
+            return { 'status': 'OK', 'returnCode': 0 };
+        }
+        if (failedProportion > config.hatchFailRateThreshold) {
+            return { 'status': 'FAILED', 'returnCode': 1 };
+        }
+        return { 'status': 'WARNING', 'returnCode': 13 };
+    }
+
+    exit () {
+        process.exit(this.getIngestionStatus().returnCode);
+    }
+
     /* eslint-disable no-empty-function, no-unused-vars */
     overrideConfig (newConfig) {
     }
     /* eslint-enable */
 
     async addAsset (asset) {
+        const assets = asset.flattenAssetTree();
+        this.assetsCount.total += assets.length;
         if (!asset.isValidTree()) {
+            this.assetsCount.failed += assets.length;
             logger.error(
                 `Asset ${asset.canonicalURI} has failed to ingest or it has failed children`);
             return;
         }
 
-        const assets = asset.flattenAssetTree();
         await this.hatchWriter.writeAssets(assets);
     }
 
-    async run () {
+    async run (exit = true) {
         logger.info(`Running ingester ${this.name} ` +
                     `from ${config.fromDate.toISOString()} ` +
                     `to ${config.toDate.toISOString()}...`);
+
         await this.hatchWriter.setup();
+
         try {
             await this.ingest();
         } catch (err) {
@@ -65,8 +85,17 @@ class Ingester {
             // failed assets.
             throw err;
         }
+
         await this.hatchWriter.writeManifest();
-        logger.info(`Ingestion done. Hatch created at: ${this.hatchWriter.path}`);
+
+        logger.info(`Ingestion done. Status: ${this.getIngestionStatus().status}`);
+        logger.info(`Total assets: ${this.assetsCount.total}`);
+        logger.info(`Failed assets: ${this.assetsCount.failed}`);
+        logger.info(`Hatch created at: ${this.hatchWriter.path}`);
+
+        if (exit) {
+            this.exit();
+        }
     }
 
     async ingest () {


### PR DESCRIPTION
RC will be 0 for none assets failed, 1 for many assets failed, 13 for
some assets failed. The failure rate threshold is configurable, and
defaults to 90% of the assets.

By default the ingester run() will exit the process. Passing exit =
false you can skip this.

https://phabricator.endlessm.com/T23489