### PR TITLE
Make revisionTag optional and allow to override it

### DIFF
--- a/lib/asset/baseAsset.js
+++ b/lib/asset/baseAsset.js
@@ -18,8 +18,9 @@ class BaseAsset {
     }
 
     get ALLOWED_METADATA() {
-        return new Set([ 'title', 'synopsis', 'thumbnail', 'canonical_uri', 'last_modified_date',
-                         'date_published', 'sequence_number', 'license', 'tags' ]);
+        return new Set([ 'title', 'synopsis', 'thumbnail', 'canonical_uri', 'revision_tag',
+                         'last_modified_date', 'date_published', 'sequence_number', 'license',
+                         'tags' ]);
     }
 
     constructor(metadata = {}, verifier = assetVerifier) {
@@ -115,6 +116,9 @@ class BaseAsset {
             case 'canonical_uri':
                 this.set_canonical_uri(value);
                 break;
+            case 'revision_tag':
+                this.set_revision_tag(value);
+                break;
             case 'last_modified_date':
                 this.set_last_modified_date(value);
                 break;
@@ -165,6 +169,13 @@ class BaseAsset {
      */
     set_canonical_uri(value) {
         this._canonical_uri = value;
+    }
+
+    /**
+     * @param {string} value
+     */
+    set_revision_tag(value) {
+        this._revision_tag = value;
     }
 
     /**
@@ -262,6 +273,12 @@ class BaseAsset {
         if (this._last_modified_date) {
             metadata.lastModifiedDate = this._last_modified_date.toISOString();
             metadata.revisionTag = this._last_modified_date.toISOString();
+        }
+        if (this._revision_tag) {
+            metadata.revisionTag = this._revision_tag;
+        }
+        if (this._revision_tag === false) {
+            delete metadata.revisionTag;
         }
         if (typeof this._sequence_number !== 'undefined') {
             metadata.sequenceNumber = this._sequence_number;

--- a/lib/asset/verifier.js
+++ b/lib/asset/verifier.js
@@ -49,9 +49,6 @@ function verifyMetadata(metadata) {
     assert(metadata.tags.every(s => typeof s === 'string'),
            'Some asset tags are not strings', metadata);
 
-    assert(Boolean(metadata.revisionTag),
-           'Asset missing revisionTag', metadata);
-
     if (objectType !== 'VideoObject') {
         assert(typeof metadata.contentType === 'string',
                'Asset has invalid contentType', metadata);

--- a/test/lib/asset/blogArticle.test.js
+++ b/test/lib/asset/blogArticle.test.js
@@ -88,6 +88,20 @@ describe('BlogArticle', () => {
         const hatchMetadata = asset.to_hatch_metadata();
         expect(hatchMetadata.synopsis).to.equal('This is a line. This is the same line.');
     });
+
+    it('can override revisionTag', () => {
+        asset.set_revision_tag('TestTag');
+        asset.render();
+        const hatchMetadata = asset.to_hatch_metadata();
+        expect(hatchMetadata.revisionTag).to.equal('TestTag');
+    });
+
+    it('can delete revisionTag', () => {
+        asset.set_revision_tag(false);
+        asset.render();
+        const hatchMetadata = asset.to_hatch_metadata();
+        expect(hatchMetadata).to.not.have.property('revisionTag');
+    });
 });
 
 describe('BlogArticle with parameters', () => {


### PR DESCRIPTION
Sometimes the revisionTag can be another value rather than just the last
modified date (like the ETag or something like that), let's allow the
ingester to override the revisionTag for the asset.

Also, since the Soma pipeline is adding support to calculate the
revisionTag using hashing, let's allow the ingester to not specify
the revisionTag at all, so it's calculated down the pipeline.